### PR TITLE
[#66] Add mutable metadata trait

### DIFF
--- a/k8s-openapi-codegen-common/src/templates/impl_metadata.rs
+++ b/k8s-openapi-codegen-common/src/templates/impl_metadata.rs
@@ -20,6 +20,8 @@ pub(crate) fn generate(
 			type_generics_where = type_generics_where,
 			metadata_type_name = metadata_ty.0,
 			metadata_expr = if metadata_ty.1 { "Some(&self.metadata)" } else { "self.metadata.as_ref()" },
+			metadata_mut_expr = if metadata_ty.1 { "Some(&mut self.metadata)" } else { "self.metadata.as_mut()" },
+			set_metadata_expr = if metadata_ty.1 { "self.metadata=metadata;" } else { "self.metadata=Some(metadata);" },
 		)?;
 	}
 

--- a/k8s-openapi-codegen-common/templates/impl_metadata.rs
+++ b/k8s-openapi-codegen-common/templates/impl_metadata.rs
@@ -2,7 +2,16 @@
 impl{type_generics_impl} {crate_root}::Metadata for {type_name}{type_generics_type}{type_generics_where} {{
     type Ty = {metadata_type_name};
 
-    fn metadata(&self) -> Option<&<Self as {}::Metadata>::Ty> {{
+    fn metadata(&self) -> Option<&<Self as {0}::Metadata>::Ty> {{
         {metadata_expr}
     }}
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as {0}::Metadata>::Ty> {{
+        {metadata_mut_expr}
+    }}
+
+    fn set_metadata(&mut self, metadata: <Self as {0}::Metadata>::Ty) {{
+        {set_metadata_expr}
+    }}
+
 }}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -531,6 +531,12 @@ pub trait Metadata: Resource {
 
     /// Gets the metadata of this resource value.
     fn metadata(&self) -> Option<&<Self as Metadata>::Ty>;
+
+    /// Gets the mutable metadata of this resource value.
+    fn metadata_mut(&mut self) -> Option<&mut<Self as Metadata>::Ty>;
+
+    /// Sets the metadata of this resource value.
+    fn set_metadata(&mut self, metadata: <Self as Metadata>::Ty);
 }
 
 /// Extracts the API version of the given resource value.

--- a/src/v1_11/api/admissionregistration/v1alpha1/initializer_configuration.rs
+++ b/src/v1_11/api/admissionregistration/v1alpha1/initializer_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for InitializerConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for InitializerConfiguration {

--- a/src/v1_11/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
+++ b/src/v1_11/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for MutatingWebhookConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for MutatingWebhookConfiguration {

--- a/src/v1_11/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
+++ b/src/v1_11/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for ValidatingWebhookConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ValidatingWebhookConfiguration {

--- a/src/v1_11/api/apps/v1/controller_revision.rs
+++ b/src/v1_11/api/apps/v1/controller_revision.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ControllerRevision {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ControllerRevision {

--- a/src/v1_11/api/apps/v1/daemon_set.rs
+++ b/src/v1_11/api/apps/v1/daemon_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for DaemonSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for DaemonSet {

--- a/src/v1_11/api/apps/v1/deployment.rs
+++ b/src/v1_11/api/apps/v1/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_11/api/apps/v1/replica_set.rs
+++ b/src/v1_11/api/apps/v1/replica_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicaSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicaSet {

--- a/src/v1_11/api/apps/v1/stateful_set.rs
+++ b/src/v1_11/api/apps/v1/stateful_set.rs
@@ -699,6 +699,15 @@ impl crate::Metadata for StatefulSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StatefulSet {

--- a/src/v1_11/api/apps/v1beta1/controller_revision.rs
+++ b/src/v1_11/api/apps/v1beta1/controller_revision.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ControllerRevision {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ControllerRevision {

--- a/src/v1_11/api/apps/v1beta1/deployment.rs
+++ b/src/v1_11/api/apps/v1beta1/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_11/api/apps/v1beta1/scale.rs
+++ b/src/v1_11/api/apps/v1beta1/scale.rs
@@ -414,6 +414,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_11/api/apps/v1beta1/stateful_set.rs
+++ b/src/v1_11/api/apps/v1beta1/stateful_set.rs
@@ -699,6 +699,15 @@ impl crate::Metadata for StatefulSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StatefulSet {

--- a/src/v1_11/api/apps/v1beta2/controller_revision.rs
+++ b/src/v1_11/api/apps/v1beta2/controller_revision.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ControllerRevision {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ControllerRevision {

--- a/src/v1_11/api/apps/v1beta2/daemon_set.rs
+++ b/src/v1_11/api/apps/v1beta2/daemon_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for DaemonSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for DaemonSet {

--- a/src/v1_11/api/apps/v1beta2/deployment.rs
+++ b/src/v1_11/api/apps/v1beta2/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_11/api/apps/v1beta2/replica_set.rs
+++ b/src/v1_11/api/apps/v1beta2/replica_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicaSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicaSet {

--- a/src/v1_11/api/apps/v1beta2/scale.rs
+++ b/src/v1_11/api/apps/v1beta2/scale.rs
@@ -606,6 +606,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_11/api/apps/v1beta2/stateful_set.rs
+++ b/src/v1_11/api/apps/v1beta2/stateful_set.rs
@@ -699,6 +699,15 @@ impl crate::Metadata for StatefulSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StatefulSet {

--- a/src/v1_11/api/authentication/v1/token_review.rs
+++ b/src/v1_11/api/authentication/v1/token_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for TokenReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for TokenReview {

--- a/src/v1_11/api/authentication/v1beta1/token_review.rs
+++ b/src/v1_11/api/authentication/v1beta1/token_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for TokenReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for TokenReview {

--- a/src/v1_11/api/authorization/v1/local_subject_access_review.rs
+++ b/src/v1_11/api/authorization/v1/local_subject_access_review.rs
@@ -70,6 +70,15 @@ impl crate::Metadata for LocalSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LocalSubjectAccessReview {

--- a/src/v1_11/api/authorization/v1/self_subject_access_review.rs
+++ b/src/v1_11/api/authorization/v1/self_subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectAccessReview {

--- a/src/v1_11/api/authorization/v1/self_subject_rules_review.rs
+++ b/src/v1_11/api/authorization/v1/self_subject_rules_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectRulesReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectRulesReview {

--- a/src/v1_11/api/authorization/v1/subject_access_review.rs
+++ b/src/v1_11/api/authorization/v1/subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SubjectAccessReview {

--- a/src/v1_11/api/authorization/v1beta1/local_subject_access_review.rs
+++ b/src/v1_11/api/authorization/v1beta1/local_subject_access_review.rs
@@ -70,6 +70,15 @@ impl crate::Metadata for LocalSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LocalSubjectAccessReview {

--- a/src/v1_11/api/authorization/v1beta1/self_subject_access_review.rs
+++ b/src/v1_11/api/authorization/v1beta1/self_subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectAccessReview {

--- a/src/v1_11/api/authorization/v1beta1/self_subject_rules_review.rs
+++ b/src/v1_11/api/authorization/v1beta1/self_subject_rules_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectRulesReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectRulesReview {

--- a/src/v1_11/api/authorization/v1beta1/subject_access_review.rs
+++ b/src/v1_11/api/authorization/v1beta1/subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SubjectAccessReview {

--- a/src/v1_11/api/autoscaling/v1/horizontal_pod_autoscaler.rs
+++ b/src/v1_11/api/autoscaling/v1/horizontal_pod_autoscaler.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for HorizontalPodAutoscaler {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for HorizontalPodAutoscaler {

--- a/src/v1_11/api/autoscaling/v1/scale.rs
+++ b/src/v1_11/api/autoscaling/v1/scale.rs
@@ -798,6 +798,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_11/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
+++ b/src/v1_11/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for HorizontalPodAutoscaler {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for HorizontalPodAutoscaler {

--- a/src/v1_11/api/batch/v1/job.rs
+++ b/src/v1_11/api/batch/v1/job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Job {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Job {

--- a/src/v1_11/api/batch/v1beta1/cron_job.rs
+++ b/src/v1_11/api/batch/v1beta1/cron_job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for CronJob {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CronJob {

--- a/src/v1_11/api/batch/v2alpha1/cron_job.rs
+++ b/src/v1_11/api/batch/v2alpha1/cron_job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for CronJob {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CronJob {

--- a/src/v1_11/api/certificates/v1beta1/certificate_signing_request.rs
+++ b/src/v1_11/api/certificates/v1beta1/certificate_signing_request.rs
@@ -603,6 +603,15 @@ impl crate::Metadata for CertificateSigningRequest {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CertificateSigningRequest {

--- a/src/v1_11/api/core/v1/binding.rs
+++ b/src/v1_11/api/core/v1/binding.rs
@@ -115,6 +115,15 @@ impl crate::Metadata for Binding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Binding {

--- a/src/v1_11/api/core/v1/component_status.rs
+++ b/src/v1_11/api/core/v1/component_status.rs
@@ -183,6 +183,15 @@ impl crate::Metadata for ComponentStatus {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ComponentStatus {

--- a/src/v1_11/api/core/v1/config_map.rs
+++ b/src/v1_11/api/core/v1/config_map.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ConfigMap {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ConfigMap {

--- a/src/v1_11/api/core/v1/endpoints.rs
+++ b/src/v1_11/api/core/v1/endpoints.rs
@@ -513,6 +513,15 @@ impl crate::Metadata for Endpoints {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Endpoints {

--- a/src/v1_11/api/core/v1/event.rs
+++ b/src/v1_11/api/core/v1/event.rs
@@ -541,6 +541,15 @@ impl crate::Metadata for Event {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         Some(&self.metadata)
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        Some(&mut self.metadata)
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=metadata;
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Event {

--- a/src/v1_11/api/core/v1/limit_range.rs
+++ b/src/v1_11/api/core/v1/limit_range.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for LimitRange {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LimitRange {

--- a/src/v1_11/api/core/v1/namespace.rs
+++ b/src/v1_11/api/core/v1/namespace.rs
@@ -568,6 +568,15 @@ impl crate::Metadata for Namespace {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Namespace {

--- a/src/v1_11/api/core/v1/node.rs
+++ b/src/v1_11/api/core/v1/node.rs
@@ -1043,6 +1043,15 @@ impl crate::Metadata for Node {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Node {

--- a/src/v1_11/api/core/v1/persistent_volume.rs
+++ b/src/v1_11/api/core/v1/persistent_volume.rs
@@ -563,6 +563,15 @@ impl crate::Metadata for PersistentVolume {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PersistentVolume {

--- a/src/v1_11/api/core/v1/persistent_volume_claim.rs
+++ b/src/v1_11/api/core/v1/persistent_volume_claim.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for PersistentVolumeClaim {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PersistentVolumeClaim {

--- a/src/v1_11/api/core/v1/pod.rs
+++ b/src/v1_11/api/core/v1/pod.rs
@@ -1797,6 +1797,15 @@ impl crate::Metadata for Pod {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Pod {

--- a/src/v1_11/api/core/v1/pod_template.rs
+++ b/src/v1_11/api/core/v1/pod_template.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for PodTemplate {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodTemplate {

--- a/src/v1_11/api/core/v1/replication_controller.rs
+++ b/src/v1_11/api/core/v1/replication_controller.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicationController {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicationController {

--- a/src/v1_11/api/core/v1/resource_quota.rs
+++ b/src/v1_11/api/core/v1/resource_quota.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ResourceQuota {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ResourceQuota {

--- a/src/v1_11/api/core/v1/secret.rs
+++ b/src/v1_11/api/core/v1/secret.rs
@@ -508,6 +508,15 @@ impl crate::Metadata for Secret {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Secret {

--- a/src/v1_11/api/core/v1/service.rs
+++ b/src/v1_11/api/core/v1/service.rs
@@ -1194,6 +1194,15 @@ impl crate::Metadata for Service {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Service {

--- a/src/v1_11/api/core/v1/service_account.rs
+++ b/src/v1_11/api/core/v1/service_account.rs
@@ -508,6 +508,15 @@ impl crate::Metadata for ServiceAccount {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ServiceAccount {

--- a/src/v1_11/api/events/v1beta1/event.rs
+++ b/src/v1_11/api/events/v1beta1/event.rs
@@ -540,6 +540,15 @@ impl crate::Metadata for Event {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Event {

--- a/src/v1_11/api/extensions/v1beta1/daemon_set.rs
+++ b/src/v1_11/api/extensions/v1beta1/daemon_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for DaemonSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for DaemonSet {

--- a/src/v1_11/api/extensions/v1beta1/deployment.rs
+++ b/src/v1_11/api/extensions/v1beta1/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_11/api/extensions/v1beta1/ingress.rs
+++ b/src/v1_11/api/extensions/v1beta1/ingress.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Ingress {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Ingress {

--- a/src/v1_11/api/extensions/v1beta1/network_policy.rs
+++ b/src/v1_11/api/extensions/v1beta1/network_policy.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for NetworkPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for NetworkPolicy {

--- a/src/v1_11/api/extensions/v1beta1/pod_security_policy.rs
+++ b/src/v1_11/api/extensions/v1beta1/pod_security_policy.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for PodSecurityPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodSecurityPolicy {

--- a/src/v1_11/api/extensions/v1beta1/replica_set.rs
+++ b/src/v1_11/api/extensions/v1beta1/replica_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicaSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicaSet {

--- a/src/v1_11/api/extensions/v1beta1/scale.rs
+++ b/src/v1_11/api/extensions/v1beta1/scale.rs
@@ -606,6 +606,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_11/api/networking/v1/network_policy.rs
+++ b/src/v1_11/api/networking/v1/network_policy.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for NetworkPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for NetworkPolicy {

--- a/src/v1_11/api/policy/v1beta1/eviction.rs
+++ b/src/v1_11/api/policy/v1beta1/eviction.rs
@@ -74,6 +74,15 @@ impl crate::Metadata for Eviction {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Eviction {

--- a/src/v1_11/api/policy/v1beta1/pod_disruption_budget.rs
+++ b/src/v1_11/api/policy/v1beta1/pod_disruption_budget.rs
@@ -696,6 +696,15 @@ impl crate::Metadata for PodDisruptionBudget {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodDisruptionBudget {

--- a/src/v1_11/api/policy/v1beta1/pod_security_policy.rs
+++ b/src/v1_11/api/policy/v1beta1/pod_security_policy.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for PodSecurityPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodSecurityPolicy {

--- a/src/v1_11/api/rbac/v1/cluster_role.rs
+++ b/src/v1_11/api/rbac/v1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_11/api/rbac/v1/cluster_role_binding.rs
+++ b/src/v1_11/api/rbac/v1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_11/api/rbac/v1/role.rs
+++ b/src/v1_11/api/rbac/v1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_11/api/rbac/v1/role_binding.rs
+++ b/src/v1_11/api/rbac/v1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_11/api/rbac/v1alpha1/cluster_role.rs
+++ b/src/v1_11/api/rbac/v1alpha1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_11/api/rbac/v1alpha1/cluster_role_binding.rs
+++ b/src/v1_11/api/rbac/v1alpha1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_11/api/rbac/v1alpha1/role.rs
+++ b/src/v1_11/api/rbac/v1alpha1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_11/api/rbac/v1alpha1/role_binding.rs
+++ b/src/v1_11/api/rbac/v1alpha1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_11/api/rbac/v1beta1/cluster_role.rs
+++ b/src/v1_11/api/rbac/v1beta1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_11/api/rbac/v1beta1/cluster_role_binding.rs
+++ b/src/v1_11/api/rbac/v1beta1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_11/api/rbac/v1beta1/role.rs
+++ b/src/v1_11/api/rbac/v1beta1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_11/api/rbac/v1beta1/role_binding.rs
+++ b/src/v1_11/api/rbac/v1beta1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_11/api/scheduling/v1alpha1/priority_class.rs
+++ b/src/v1_11/api/scheduling/v1alpha1/priority_class.rs
@@ -392,6 +392,15 @@ impl crate::Metadata for PriorityClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PriorityClass {

--- a/src/v1_11/api/scheduling/v1beta1/priority_class.rs
+++ b/src/v1_11/api/scheduling/v1beta1/priority_class.rs
@@ -392,6 +392,15 @@ impl crate::Metadata for PriorityClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PriorityClass {

--- a/src/v1_11/api/settings/v1alpha1/pod_preset.rs
+++ b/src/v1_11/api/settings/v1alpha1/pod_preset.rs
@@ -500,6 +500,15 @@ impl crate::Metadata for PodPreset {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodPreset {

--- a/src/v1_11/api/storage/v1/storage_class.rs
+++ b/src/v1_11/api/storage/v1/storage_class.rs
@@ -406,6 +406,15 @@ impl crate::Metadata for StorageClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StorageClass {

--- a/src/v1_11/api/storage/v1alpha1/volume_attachment.rs
+++ b/src/v1_11/api/storage/v1alpha1/volume_attachment.rs
@@ -391,6 +391,15 @@ impl crate::Metadata for VolumeAttachment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for VolumeAttachment {

--- a/src/v1_11/api/storage/v1beta1/storage_class.rs
+++ b/src/v1_11/api/storage/v1beta1/storage_class.rs
@@ -406,6 +406,15 @@ impl crate::Metadata for StorageClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StorageClass {

--- a/src/v1_11/api/storage/v1beta1/volume_attachment.rs
+++ b/src/v1_11/api/storage/v1beta1/volume_attachment.rs
@@ -391,6 +391,15 @@ impl crate::Metadata for VolumeAttachment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for VolumeAttachment {

--- a/src/v1_11/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
+++ b/src/v1_11/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for CustomResourceDefinition {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CustomResourceDefinition {

--- a/src/v1_11/apimachinery/pkg/apis/meta/v1/status.rs
+++ b/src/v1_11/apimachinery/pkg/apis/meta/v1/status.rs
@@ -35,6 +35,15 @@ impl crate::Metadata for Status {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Status {

--- a/src/v1_11/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
+++ b/src/v1_11/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for APIService {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for APIService {

--- a/src/v1_11/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
+++ b/src/v1_11/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for APIService {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for APIService {

--- a/src/v1_11/list.rs
+++ b/src/v1_11/list.rs
@@ -23,6 +23,15 @@ impl<T> crate::Metadata for List<T> where T: crate::ListableResource {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de, T> serde::Deserialize<'de> for List<T> where T: serde::Deserialize<'de> + crate::ListableResource {

--- a/src/v1_12/api/admissionregistration/v1alpha1/initializer_configuration.rs
+++ b/src/v1_12/api/admissionregistration/v1alpha1/initializer_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for InitializerConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for InitializerConfiguration {

--- a/src/v1_12/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
+++ b/src/v1_12/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for MutatingWebhookConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for MutatingWebhookConfiguration {

--- a/src/v1_12/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
+++ b/src/v1_12/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for ValidatingWebhookConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ValidatingWebhookConfiguration {

--- a/src/v1_12/api/apps/v1/controller_revision.rs
+++ b/src/v1_12/api/apps/v1/controller_revision.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ControllerRevision {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ControllerRevision {

--- a/src/v1_12/api/apps/v1/daemon_set.rs
+++ b/src/v1_12/api/apps/v1/daemon_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for DaemonSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for DaemonSet {

--- a/src/v1_12/api/apps/v1/deployment.rs
+++ b/src/v1_12/api/apps/v1/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_12/api/apps/v1/replica_set.rs
+++ b/src/v1_12/api/apps/v1/replica_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicaSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicaSet {

--- a/src/v1_12/api/apps/v1/stateful_set.rs
+++ b/src/v1_12/api/apps/v1/stateful_set.rs
@@ -699,6 +699,15 @@ impl crate::Metadata for StatefulSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StatefulSet {

--- a/src/v1_12/api/apps/v1beta1/controller_revision.rs
+++ b/src/v1_12/api/apps/v1beta1/controller_revision.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ControllerRevision {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ControllerRevision {

--- a/src/v1_12/api/apps/v1beta1/deployment.rs
+++ b/src/v1_12/api/apps/v1beta1/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_12/api/apps/v1beta1/scale.rs
+++ b/src/v1_12/api/apps/v1beta1/scale.rs
@@ -414,6 +414,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_12/api/apps/v1beta1/stateful_set.rs
+++ b/src/v1_12/api/apps/v1beta1/stateful_set.rs
@@ -699,6 +699,15 @@ impl crate::Metadata for StatefulSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StatefulSet {

--- a/src/v1_12/api/apps/v1beta2/controller_revision.rs
+++ b/src/v1_12/api/apps/v1beta2/controller_revision.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ControllerRevision {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ControllerRevision {

--- a/src/v1_12/api/apps/v1beta2/daemon_set.rs
+++ b/src/v1_12/api/apps/v1beta2/daemon_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for DaemonSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for DaemonSet {

--- a/src/v1_12/api/apps/v1beta2/deployment.rs
+++ b/src/v1_12/api/apps/v1beta2/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_12/api/apps/v1beta2/replica_set.rs
+++ b/src/v1_12/api/apps/v1beta2/replica_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicaSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicaSet {

--- a/src/v1_12/api/apps/v1beta2/scale.rs
+++ b/src/v1_12/api/apps/v1beta2/scale.rs
@@ -606,6 +606,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_12/api/apps/v1beta2/stateful_set.rs
+++ b/src/v1_12/api/apps/v1beta2/stateful_set.rs
@@ -699,6 +699,15 @@ impl crate::Metadata for StatefulSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StatefulSet {

--- a/src/v1_12/api/authentication/v1/token_review.rs
+++ b/src/v1_12/api/authentication/v1/token_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for TokenReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for TokenReview {

--- a/src/v1_12/api/authentication/v1beta1/token_review.rs
+++ b/src/v1_12/api/authentication/v1beta1/token_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for TokenReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for TokenReview {

--- a/src/v1_12/api/authorization/v1/local_subject_access_review.rs
+++ b/src/v1_12/api/authorization/v1/local_subject_access_review.rs
@@ -70,6 +70,15 @@ impl crate::Metadata for LocalSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LocalSubjectAccessReview {

--- a/src/v1_12/api/authorization/v1/self_subject_access_review.rs
+++ b/src/v1_12/api/authorization/v1/self_subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectAccessReview {

--- a/src/v1_12/api/authorization/v1/self_subject_rules_review.rs
+++ b/src/v1_12/api/authorization/v1/self_subject_rules_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectRulesReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectRulesReview {

--- a/src/v1_12/api/authorization/v1/subject_access_review.rs
+++ b/src/v1_12/api/authorization/v1/subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SubjectAccessReview {

--- a/src/v1_12/api/authorization/v1beta1/local_subject_access_review.rs
+++ b/src/v1_12/api/authorization/v1beta1/local_subject_access_review.rs
@@ -70,6 +70,15 @@ impl crate::Metadata for LocalSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LocalSubjectAccessReview {

--- a/src/v1_12/api/authorization/v1beta1/self_subject_access_review.rs
+++ b/src/v1_12/api/authorization/v1beta1/self_subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectAccessReview {

--- a/src/v1_12/api/authorization/v1beta1/self_subject_rules_review.rs
+++ b/src/v1_12/api/authorization/v1beta1/self_subject_rules_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectRulesReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectRulesReview {

--- a/src/v1_12/api/authorization/v1beta1/subject_access_review.rs
+++ b/src/v1_12/api/authorization/v1beta1/subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SubjectAccessReview {

--- a/src/v1_12/api/autoscaling/v1/horizontal_pod_autoscaler.rs
+++ b/src/v1_12/api/autoscaling/v1/horizontal_pod_autoscaler.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for HorizontalPodAutoscaler {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for HorizontalPodAutoscaler {

--- a/src/v1_12/api/autoscaling/v1/scale.rs
+++ b/src/v1_12/api/autoscaling/v1/scale.rs
@@ -798,6 +798,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_12/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
+++ b/src/v1_12/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for HorizontalPodAutoscaler {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for HorizontalPodAutoscaler {

--- a/src/v1_12/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
+++ b/src/v1_12/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for HorizontalPodAutoscaler {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for HorizontalPodAutoscaler {

--- a/src/v1_12/api/batch/v1/job.rs
+++ b/src/v1_12/api/batch/v1/job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Job {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Job {

--- a/src/v1_12/api/batch/v1beta1/cron_job.rs
+++ b/src/v1_12/api/batch/v1beta1/cron_job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for CronJob {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CronJob {

--- a/src/v1_12/api/batch/v2alpha1/cron_job.rs
+++ b/src/v1_12/api/batch/v2alpha1/cron_job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for CronJob {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CronJob {

--- a/src/v1_12/api/certificates/v1beta1/certificate_signing_request.rs
+++ b/src/v1_12/api/certificates/v1beta1/certificate_signing_request.rs
@@ -603,6 +603,15 @@ impl crate::Metadata for CertificateSigningRequest {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CertificateSigningRequest {

--- a/src/v1_12/api/coordination/v1beta1/lease.rs
+++ b/src/v1_12/api/coordination/v1beta1/lease.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for Lease {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Lease {

--- a/src/v1_12/api/core/v1/binding.rs
+++ b/src/v1_12/api/core/v1/binding.rs
@@ -115,6 +115,15 @@ impl crate::Metadata for Binding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Binding {

--- a/src/v1_12/api/core/v1/component_status.rs
+++ b/src/v1_12/api/core/v1/component_status.rs
@@ -183,6 +183,15 @@ impl crate::Metadata for ComponentStatus {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ComponentStatus {

--- a/src/v1_12/api/core/v1/config_map.rs
+++ b/src/v1_12/api/core/v1/config_map.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ConfigMap {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ConfigMap {

--- a/src/v1_12/api/core/v1/endpoints.rs
+++ b/src/v1_12/api/core/v1/endpoints.rs
@@ -513,6 +513,15 @@ impl crate::Metadata for Endpoints {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Endpoints {

--- a/src/v1_12/api/core/v1/event.rs
+++ b/src/v1_12/api/core/v1/event.rs
@@ -541,6 +541,15 @@ impl crate::Metadata for Event {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         Some(&self.metadata)
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        Some(&mut self.metadata)
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=metadata;
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Event {

--- a/src/v1_12/api/core/v1/limit_range.rs
+++ b/src/v1_12/api/core/v1/limit_range.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for LimitRange {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LimitRange {

--- a/src/v1_12/api/core/v1/namespace.rs
+++ b/src/v1_12/api/core/v1/namespace.rs
@@ -568,6 +568,15 @@ impl crate::Metadata for Namespace {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Namespace {

--- a/src/v1_12/api/core/v1/node.rs
+++ b/src/v1_12/api/core/v1/node.rs
@@ -1043,6 +1043,15 @@ impl crate::Metadata for Node {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Node {

--- a/src/v1_12/api/core/v1/persistent_volume.rs
+++ b/src/v1_12/api/core/v1/persistent_volume.rs
@@ -563,6 +563,15 @@ impl crate::Metadata for PersistentVolume {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PersistentVolume {

--- a/src/v1_12/api/core/v1/persistent_volume_claim.rs
+++ b/src/v1_12/api/core/v1/persistent_volume_claim.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for PersistentVolumeClaim {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PersistentVolumeClaim {

--- a/src/v1_12/api/core/v1/pod.rs
+++ b/src/v1_12/api/core/v1/pod.rs
@@ -1797,6 +1797,15 @@ impl crate::Metadata for Pod {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Pod {

--- a/src/v1_12/api/core/v1/pod_template.rs
+++ b/src/v1_12/api/core/v1/pod_template.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for PodTemplate {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodTemplate {

--- a/src/v1_12/api/core/v1/replication_controller.rs
+++ b/src/v1_12/api/core/v1/replication_controller.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicationController {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicationController {

--- a/src/v1_12/api/core/v1/resource_quota.rs
+++ b/src/v1_12/api/core/v1/resource_quota.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ResourceQuota {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ResourceQuota {

--- a/src/v1_12/api/core/v1/secret.rs
+++ b/src/v1_12/api/core/v1/secret.rs
@@ -508,6 +508,15 @@ impl crate::Metadata for Secret {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Secret {

--- a/src/v1_12/api/core/v1/service.rs
+++ b/src/v1_12/api/core/v1/service.rs
@@ -1194,6 +1194,15 @@ impl crate::Metadata for Service {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Service {

--- a/src/v1_12/api/core/v1/service_account.rs
+++ b/src/v1_12/api/core/v1/service_account.rs
@@ -508,6 +508,15 @@ impl crate::Metadata for ServiceAccount {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ServiceAccount {

--- a/src/v1_12/api/events/v1beta1/event.rs
+++ b/src/v1_12/api/events/v1beta1/event.rs
@@ -540,6 +540,15 @@ impl crate::Metadata for Event {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Event {

--- a/src/v1_12/api/extensions/v1beta1/daemon_set.rs
+++ b/src/v1_12/api/extensions/v1beta1/daemon_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for DaemonSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for DaemonSet {

--- a/src/v1_12/api/extensions/v1beta1/deployment.rs
+++ b/src/v1_12/api/extensions/v1beta1/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_12/api/extensions/v1beta1/ingress.rs
+++ b/src/v1_12/api/extensions/v1beta1/ingress.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Ingress {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Ingress {

--- a/src/v1_12/api/extensions/v1beta1/network_policy.rs
+++ b/src/v1_12/api/extensions/v1beta1/network_policy.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for NetworkPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for NetworkPolicy {

--- a/src/v1_12/api/extensions/v1beta1/pod_security_policy.rs
+++ b/src/v1_12/api/extensions/v1beta1/pod_security_policy.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for PodSecurityPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodSecurityPolicy {

--- a/src/v1_12/api/extensions/v1beta1/replica_set.rs
+++ b/src/v1_12/api/extensions/v1beta1/replica_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicaSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicaSet {

--- a/src/v1_12/api/extensions/v1beta1/scale.rs
+++ b/src/v1_12/api/extensions/v1beta1/scale.rs
@@ -606,6 +606,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_12/api/networking/v1/network_policy.rs
+++ b/src/v1_12/api/networking/v1/network_policy.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for NetworkPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for NetworkPolicy {

--- a/src/v1_12/api/policy/v1beta1/eviction.rs
+++ b/src/v1_12/api/policy/v1beta1/eviction.rs
@@ -74,6 +74,15 @@ impl crate::Metadata for Eviction {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Eviction {

--- a/src/v1_12/api/policy/v1beta1/pod_disruption_budget.rs
+++ b/src/v1_12/api/policy/v1beta1/pod_disruption_budget.rs
@@ -696,6 +696,15 @@ impl crate::Metadata for PodDisruptionBudget {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodDisruptionBudget {

--- a/src/v1_12/api/policy/v1beta1/pod_security_policy.rs
+++ b/src/v1_12/api/policy/v1beta1/pod_security_policy.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for PodSecurityPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodSecurityPolicy {

--- a/src/v1_12/api/rbac/v1/cluster_role.rs
+++ b/src/v1_12/api/rbac/v1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_12/api/rbac/v1/cluster_role_binding.rs
+++ b/src/v1_12/api/rbac/v1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_12/api/rbac/v1/role.rs
+++ b/src/v1_12/api/rbac/v1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_12/api/rbac/v1/role_binding.rs
+++ b/src/v1_12/api/rbac/v1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_12/api/rbac/v1alpha1/cluster_role.rs
+++ b/src/v1_12/api/rbac/v1alpha1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_12/api/rbac/v1alpha1/cluster_role_binding.rs
+++ b/src/v1_12/api/rbac/v1alpha1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_12/api/rbac/v1alpha1/role.rs
+++ b/src/v1_12/api/rbac/v1alpha1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_12/api/rbac/v1alpha1/role_binding.rs
+++ b/src/v1_12/api/rbac/v1alpha1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_12/api/rbac/v1beta1/cluster_role.rs
+++ b/src/v1_12/api/rbac/v1beta1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_12/api/rbac/v1beta1/cluster_role_binding.rs
+++ b/src/v1_12/api/rbac/v1beta1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_12/api/rbac/v1beta1/role.rs
+++ b/src/v1_12/api/rbac/v1beta1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_12/api/rbac/v1beta1/role_binding.rs
+++ b/src/v1_12/api/rbac/v1beta1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_12/api/scheduling/v1alpha1/priority_class.rs
+++ b/src/v1_12/api/scheduling/v1alpha1/priority_class.rs
@@ -392,6 +392,15 @@ impl crate::Metadata for PriorityClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PriorityClass {

--- a/src/v1_12/api/scheduling/v1beta1/priority_class.rs
+++ b/src/v1_12/api/scheduling/v1beta1/priority_class.rs
@@ -392,6 +392,15 @@ impl crate::Metadata for PriorityClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PriorityClass {

--- a/src/v1_12/api/settings/v1alpha1/pod_preset.rs
+++ b/src/v1_12/api/settings/v1alpha1/pod_preset.rs
@@ -500,6 +500,15 @@ impl crate::Metadata for PodPreset {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodPreset {

--- a/src/v1_12/api/storage/v1/storage_class.rs
+++ b/src/v1_12/api/storage/v1/storage_class.rs
@@ -406,6 +406,15 @@ impl crate::Metadata for StorageClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StorageClass {

--- a/src/v1_12/api/storage/v1alpha1/volume_attachment.rs
+++ b/src/v1_12/api/storage/v1alpha1/volume_attachment.rs
@@ -391,6 +391,15 @@ impl crate::Metadata for VolumeAttachment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for VolumeAttachment {

--- a/src/v1_12/api/storage/v1beta1/storage_class.rs
+++ b/src/v1_12/api/storage/v1beta1/storage_class.rs
@@ -406,6 +406,15 @@ impl crate::Metadata for StorageClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StorageClass {

--- a/src/v1_12/api/storage/v1beta1/volume_attachment.rs
+++ b/src/v1_12/api/storage/v1beta1/volume_attachment.rs
@@ -391,6 +391,15 @@ impl crate::Metadata for VolumeAttachment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for VolumeAttachment {

--- a/src/v1_12/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
+++ b/src/v1_12/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for CustomResourceDefinition {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CustomResourceDefinition {

--- a/src/v1_12/apimachinery/pkg/apis/meta/v1/status.rs
+++ b/src/v1_12/apimachinery/pkg/apis/meta/v1/status.rs
@@ -35,6 +35,15 @@ impl crate::Metadata for Status {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Status {

--- a/src/v1_12/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
+++ b/src/v1_12/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for APIService {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for APIService {

--- a/src/v1_12/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
+++ b/src/v1_12/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for APIService {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for APIService {

--- a/src/v1_12/list.rs
+++ b/src/v1_12/list.rs
@@ -23,6 +23,15 @@ impl<T> crate::Metadata for List<T> where T: crate::ListableResource {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de, T> serde::Deserialize<'de> for List<T> where T: serde::Deserialize<'de> + crate::ListableResource {

--- a/src/v1_13/api/admissionregistration/v1alpha1/initializer_configuration.rs
+++ b/src/v1_13/api/admissionregistration/v1alpha1/initializer_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for InitializerConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for InitializerConfiguration {

--- a/src/v1_13/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
+++ b/src/v1_13/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for MutatingWebhookConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for MutatingWebhookConfiguration {

--- a/src/v1_13/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
+++ b/src/v1_13/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for ValidatingWebhookConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ValidatingWebhookConfiguration {

--- a/src/v1_13/api/apps/v1/controller_revision.rs
+++ b/src/v1_13/api/apps/v1/controller_revision.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ControllerRevision {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ControllerRevision {

--- a/src/v1_13/api/apps/v1/daemon_set.rs
+++ b/src/v1_13/api/apps/v1/daemon_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for DaemonSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for DaemonSet {

--- a/src/v1_13/api/apps/v1/deployment.rs
+++ b/src/v1_13/api/apps/v1/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_13/api/apps/v1/replica_set.rs
+++ b/src/v1_13/api/apps/v1/replica_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicaSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicaSet {

--- a/src/v1_13/api/apps/v1/stateful_set.rs
+++ b/src/v1_13/api/apps/v1/stateful_set.rs
@@ -699,6 +699,15 @@ impl crate::Metadata for StatefulSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StatefulSet {

--- a/src/v1_13/api/apps/v1beta1/controller_revision.rs
+++ b/src/v1_13/api/apps/v1beta1/controller_revision.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ControllerRevision {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ControllerRevision {

--- a/src/v1_13/api/apps/v1beta1/deployment.rs
+++ b/src/v1_13/api/apps/v1beta1/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_13/api/apps/v1beta1/scale.rs
+++ b/src/v1_13/api/apps/v1beta1/scale.rs
@@ -414,6 +414,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_13/api/apps/v1beta1/stateful_set.rs
+++ b/src/v1_13/api/apps/v1beta1/stateful_set.rs
@@ -699,6 +699,15 @@ impl crate::Metadata for StatefulSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StatefulSet {

--- a/src/v1_13/api/apps/v1beta2/controller_revision.rs
+++ b/src/v1_13/api/apps/v1beta2/controller_revision.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ControllerRevision {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ControllerRevision {

--- a/src/v1_13/api/apps/v1beta2/daemon_set.rs
+++ b/src/v1_13/api/apps/v1beta2/daemon_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for DaemonSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for DaemonSet {

--- a/src/v1_13/api/apps/v1beta2/deployment.rs
+++ b/src/v1_13/api/apps/v1beta2/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_13/api/apps/v1beta2/replica_set.rs
+++ b/src/v1_13/api/apps/v1beta2/replica_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicaSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicaSet {

--- a/src/v1_13/api/apps/v1beta2/scale.rs
+++ b/src/v1_13/api/apps/v1beta2/scale.rs
@@ -606,6 +606,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_13/api/apps/v1beta2/stateful_set.rs
+++ b/src/v1_13/api/apps/v1beta2/stateful_set.rs
@@ -699,6 +699,15 @@ impl crate::Metadata for StatefulSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StatefulSet {

--- a/src/v1_13/api/auditregistration/v1alpha1/audit_sink.rs
+++ b/src/v1_13/api/auditregistration/v1alpha1/audit_sink.rs
@@ -385,6 +385,15 @@ impl crate::Metadata for AuditSink {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for AuditSink {

--- a/src/v1_13/api/authentication/v1/token_review.rs
+++ b/src/v1_13/api/authentication/v1/token_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for TokenReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for TokenReview {

--- a/src/v1_13/api/authentication/v1beta1/token_review.rs
+++ b/src/v1_13/api/authentication/v1beta1/token_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for TokenReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for TokenReview {

--- a/src/v1_13/api/authorization/v1/local_subject_access_review.rs
+++ b/src/v1_13/api/authorization/v1/local_subject_access_review.rs
@@ -70,6 +70,15 @@ impl crate::Metadata for LocalSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LocalSubjectAccessReview {

--- a/src/v1_13/api/authorization/v1/self_subject_access_review.rs
+++ b/src/v1_13/api/authorization/v1/self_subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectAccessReview {

--- a/src/v1_13/api/authorization/v1/self_subject_rules_review.rs
+++ b/src/v1_13/api/authorization/v1/self_subject_rules_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectRulesReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectRulesReview {

--- a/src/v1_13/api/authorization/v1/subject_access_review.rs
+++ b/src/v1_13/api/authorization/v1/subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SubjectAccessReview {

--- a/src/v1_13/api/authorization/v1beta1/local_subject_access_review.rs
+++ b/src/v1_13/api/authorization/v1beta1/local_subject_access_review.rs
@@ -70,6 +70,15 @@ impl crate::Metadata for LocalSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LocalSubjectAccessReview {

--- a/src/v1_13/api/authorization/v1beta1/self_subject_access_review.rs
+++ b/src/v1_13/api/authorization/v1beta1/self_subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectAccessReview {

--- a/src/v1_13/api/authorization/v1beta1/self_subject_rules_review.rs
+++ b/src/v1_13/api/authorization/v1beta1/self_subject_rules_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectRulesReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectRulesReview {

--- a/src/v1_13/api/authorization/v1beta1/subject_access_review.rs
+++ b/src/v1_13/api/authorization/v1beta1/subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SubjectAccessReview {

--- a/src/v1_13/api/autoscaling/v1/horizontal_pod_autoscaler.rs
+++ b/src/v1_13/api/autoscaling/v1/horizontal_pod_autoscaler.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for HorizontalPodAutoscaler {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for HorizontalPodAutoscaler {

--- a/src/v1_13/api/autoscaling/v1/scale.rs
+++ b/src/v1_13/api/autoscaling/v1/scale.rs
@@ -798,6 +798,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_13/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
+++ b/src/v1_13/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for HorizontalPodAutoscaler {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for HorizontalPodAutoscaler {

--- a/src/v1_13/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
+++ b/src/v1_13/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for HorizontalPodAutoscaler {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for HorizontalPodAutoscaler {

--- a/src/v1_13/api/batch/v1/job.rs
+++ b/src/v1_13/api/batch/v1/job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Job {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Job {

--- a/src/v1_13/api/batch/v1beta1/cron_job.rs
+++ b/src/v1_13/api/batch/v1beta1/cron_job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for CronJob {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CronJob {

--- a/src/v1_13/api/batch/v2alpha1/cron_job.rs
+++ b/src/v1_13/api/batch/v2alpha1/cron_job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for CronJob {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CronJob {

--- a/src/v1_13/api/certificates/v1beta1/certificate_signing_request.rs
+++ b/src/v1_13/api/certificates/v1beta1/certificate_signing_request.rs
@@ -603,6 +603,15 @@ impl crate::Metadata for CertificateSigningRequest {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CertificateSigningRequest {

--- a/src/v1_13/api/coordination/v1beta1/lease.rs
+++ b/src/v1_13/api/coordination/v1beta1/lease.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for Lease {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Lease {

--- a/src/v1_13/api/core/v1/binding.rs
+++ b/src/v1_13/api/core/v1/binding.rs
@@ -115,6 +115,15 @@ impl crate::Metadata for Binding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Binding {

--- a/src/v1_13/api/core/v1/component_status.rs
+++ b/src/v1_13/api/core/v1/component_status.rs
@@ -183,6 +183,15 @@ impl crate::Metadata for ComponentStatus {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ComponentStatus {

--- a/src/v1_13/api/core/v1/config_map.rs
+++ b/src/v1_13/api/core/v1/config_map.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ConfigMap {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ConfigMap {

--- a/src/v1_13/api/core/v1/endpoints.rs
+++ b/src/v1_13/api/core/v1/endpoints.rs
@@ -513,6 +513,15 @@ impl crate::Metadata for Endpoints {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Endpoints {

--- a/src/v1_13/api/core/v1/event.rs
+++ b/src/v1_13/api/core/v1/event.rs
@@ -541,6 +541,15 @@ impl crate::Metadata for Event {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         Some(&self.metadata)
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        Some(&mut self.metadata)
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=metadata;
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Event {

--- a/src/v1_13/api/core/v1/limit_range.rs
+++ b/src/v1_13/api/core/v1/limit_range.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for LimitRange {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LimitRange {

--- a/src/v1_13/api/core/v1/namespace.rs
+++ b/src/v1_13/api/core/v1/namespace.rs
@@ -568,6 +568,15 @@ impl crate::Metadata for Namespace {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Namespace {

--- a/src/v1_13/api/core/v1/node.rs
+++ b/src/v1_13/api/core/v1/node.rs
@@ -1043,6 +1043,15 @@ impl crate::Metadata for Node {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Node {

--- a/src/v1_13/api/core/v1/persistent_volume.rs
+++ b/src/v1_13/api/core/v1/persistent_volume.rs
@@ -563,6 +563,15 @@ impl crate::Metadata for PersistentVolume {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PersistentVolume {

--- a/src/v1_13/api/core/v1/persistent_volume_claim.rs
+++ b/src/v1_13/api/core/v1/persistent_volume_claim.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for PersistentVolumeClaim {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PersistentVolumeClaim {

--- a/src/v1_13/api/core/v1/pod.rs
+++ b/src/v1_13/api/core/v1/pod.rs
@@ -1797,6 +1797,15 @@ impl crate::Metadata for Pod {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Pod {

--- a/src/v1_13/api/core/v1/pod_template.rs
+++ b/src/v1_13/api/core/v1/pod_template.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for PodTemplate {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodTemplate {

--- a/src/v1_13/api/core/v1/replication_controller.rs
+++ b/src/v1_13/api/core/v1/replication_controller.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicationController {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicationController {

--- a/src/v1_13/api/core/v1/resource_quota.rs
+++ b/src/v1_13/api/core/v1/resource_quota.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ResourceQuota {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ResourceQuota {

--- a/src/v1_13/api/core/v1/secret.rs
+++ b/src/v1_13/api/core/v1/secret.rs
@@ -508,6 +508,15 @@ impl crate::Metadata for Secret {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Secret {

--- a/src/v1_13/api/core/v1/service.rs
+++ b/src/v1_13/api/core/v1/service.rs
@@ -1194,6 +1194,15 @@ impl crate::Metadata for Service {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Service {

--- a/src/v1_13/api/core/v1/service_account.rs
+++ b/src/v1_13/api/core/v1/service_account.rs
@@ -508,6 +508,15 @@ impl crate::Metadata for ServiceAccount {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ServiceAccount {

--- a/src/v1_13/api/events/v1beta1/event.rs
+++ b/src/v1_13/api/events/v1beta1/event.rs
@@ -540,6 +540,15 @@ impl crate::Metadata for Event {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Event {

--- a/src/v1_13/api/extensions/v1beta1/daemon_set.rs
+++ b/src/v1_13/api/extensions/v1beta1/daemon_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for DaemonSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for DaemonSet {

--- a/src/v1_13/api/extensions/v1beta1/deployment.rs
+++ b/src/v1_13/api/extensions/v1beta1/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_13/api/extensions/v1beta1/ingress.rs
+++ b/src/v1_13/api/extensions/v1beta1/ingress.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Ingress {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Ingress {

--- a/src/v1_13/api/extensions/v1beta1/network_policy.rs
+++ b/src/v1_13/api/extensions/v1beta1/network_policy.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for NetworkPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for NetworkPolicy {

--- a/src/v1_13/api/extensions/v1beta1/pod_security_policy.rs
+++ b/src/v1_13/api/extensions/v1beta1/pod_security_policy.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for PodSecurityPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodSecurityPolicy {

--- a/src/v1_13/api/extensions/v1beta1/replica_set.rs
+++ b/src/v1_13/api/extensions/v1beta1/replica_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicaSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicaSet {

--- a/src/v1_13/api/extensions/v1beta1/scale.rs
+++ b/src/v1_13/api/extensions/v1beta1/scale.rs
@@ -606,6 +606,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_13/api/networking/v1/network_policy.rs
+++ b/src/v1_13/api/networking/v1/network_policy.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for NetworkPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for NetworkPolicy {

--- a/src/v1_13/api/policy/v1beta1/eviction.rs
+++ b/src/v1_13/api/policy/v1beta1/eviction.rs
@@ -74,6 +74,15 @@ impl crate::Metadata for Eviction {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Eviction {

--- a/src/v1_13/api/policy/v1beta1/pod_disruption_budget.rs
+++ b/src/v1_13/api/policy/v1beta1/pod_disruption_budget.rs
@@ -696,6 +696,15 @@ impl crate::Metadata for PodDisruptionBudget {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodDisruptionBudget {

--- a/src/v1_13/api/policy/v1beta1/pod_security_policy.rs
+++ b/src/v1_13/api/policy/v1beta1/pod_security_policy.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for PodSecurityPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodSecurityPolicy {

--- a/src/v1_13/api/rbac/v1/cluster_role.rs
+++ b/src/v1_13/api/rbac/v1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_13/api/rbac/v1/cluster_role_binding.rs
+++ b/src/v1_13/api/rbac/v1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_13/api/rbac/v1/role.rs
+++ b/src/v1_13/api/rbac/v1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_13/api/rbac/v1/role_binding.rs
+++ b/src/v1_13/api/rbac/v1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_13/api/rbac/v1alpha1/cluster_role.rs
+++ b/src/v1_13/api/rbac/v1alpha1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_13/api/rbac/v1alpha1/cluster_role_binding.rs
+++ b/src/v1_13/api/rbac/v1alpha1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_13/api/rbac/v1alpha1/role.rs
+++ b/src/v1_13/api/rbac/v1alpha1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_13/api/rbac/v1alpha1/role_binding.rs
+++ b/src/v1_13/api/rbac/v1alpha1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_13/api/rbac/v1beta1/cluster_role.rs
+++ b/src/v1_13/api/rbac/v1beta1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_13/api/rbac/v1beta1/cluster_role_binding.rs
+++ b/src/v1_13/api/rbac/v1beta1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_13/api/rbac/v1beta1/role.rs
+++ b/src/v1_13/api/rbac/v1beta1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_13/api/rbac/v1beta1/role_binding.rs
+++ b/src/v1_13/api/rbac/v1beta1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_13/api/scheduling/v1alpha1/priority_class.rs
+++ b/src/v1_13/api/scheduling/v1alpha1/priority_class.rs
@@ -392,6 +392,15 @@ impl crate::Metadata for PriorityClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PriorityClass {

--- a/src/v1_13/api/scheduling/v1beta1/priority_class.rs
+++ b/src/v1_13/api/scheduling/v1beta1/priority_class.rs
@@ -392,6 +392,15 @@ impl crate::Metadata for PriorityClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PriorityClass {

--- a/src/v1_13/api/settings/v1alpha1/pod_preset.rs
+++ b/src/v1_13/api/settings/v1alpha1/pod_preset.rs
@@ -500,6 +500,15 @@ impl crate::Metadata for PodPreset {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodPreset {

--- a/src/v1_13/api/storage/v1/storage_class.rs
+++ b/src/v1_13/api/storage/v1/storage_class.rs
@@ -406,6 +406,15 @@ impl crate::Metadata for StorageClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StorageClass {

--- a/src/v1_13/api/storage/v1/volume_attachment.rs
+++ b/src/v1_13/api/storage/v1/volume_attachment.rs
@@ -565,6 +565,15 @@ impl crate::Metadata for VolumeAttachment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for VolumeAttachment {

--- a/src/v1_13/api/storage/v1alpha1/volume_attachment.rs
+++ b/src/v1_13/api/storage/v1alpha1/volume_attachment.rs
@@ -391,6 +391,15 @@ impl crate::Metadata for VolumeAttachment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for VolumeAttachment {

--- a/src/v1_13/api/storage/v1beta1/storage_class.rs
+++ b/src/v1_13/api/storage/v1beta1/storage_class.rs
@@ -406,6 +406,15 @@ impl crate::Metadata for StorageClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StorageClass {

--- a/src/v1_13/api/storage/v1beta1/volume_attachment.rs
+++ b/src/v1_13/api/storage/v1beta1/volume_attachment.rs
@@ -391,6 +391,15 @@ impl crate::Metadata for VolumeAttachment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for VolumeAttachment {

--- a/src/v1_13/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
+++ b/src/v1_13/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for CustomResourceDefinition {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CustomResourceDefinition {

--- a/src/v1_13/apimachinery/pkg/apis/meta/v1/status.rs
+++ b/src/v1_13/apimachinery/pkg/apis/meta/v1/status.rs
@@ -35,6 +35,15 @@ impl crate::Metadata for Status {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Status {

--- a/src/v1_13/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
+++ b/src/v1_13/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for APIService {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for APIService {

--- a/src/v1_13/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
+++ b/src/v1_13/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for APIService {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for APIService {

--- a/src/v1_13/list.rs
+++ b/src/v1_13/list.rs
@@ -23,6 +23,15 @@ impl<T> crate::Metadata for List<T> where T: crate::ListableResource {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de, T> serde::Deserialize<'de> for List<T> where T: serde::Deserialize<'de> + crate::ListableResource {

--- a/src/v1_14/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
+++ b/src/v1_14/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for MutatingWebhookConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for MutatingWebhookConfiguration {

--- a/src/v1_14/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
+++ b/src/v1_14/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for ValidatingWebhookConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ValidatingWebhookConfiguration {

--- a/src/v1_14/api/apps/v1/controller_revision.rs
+++ b/src/v1_14/api/apps/v1/controller_revision.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ControllerRevision {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ControllerRevision {

--- a/src/v1_14/api/apps/v1/daemon_set.rs
+++ b/src/v1_14/api/apps/v1/daemon_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for DaemonSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for DaemonSet {

--- a/src/v1_14/api/apps/v1/deployment.rs
+++ b/src/v1_14/api/apps/v1/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_14/api/apps/v1/replica_set.rs
+++ b/src/v1_14/api/apps/v1/replica_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicaSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicaSet {

--- a/src/v1_14/api/apps/v1/stateful_set.rs
+++ b/src/v1_14/api/apps/v1/stateful_set.rs
@@ -699,6 +699,15 @@ impl crate::Metadata for StatefulSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StatefulSet {

--- a/src/v1_14/api/apps/v1beta1/controller_revision.rs
+++ b/src/v1_14/api/apps/v1beta1/controller_revision.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ControllerRevision {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ControllerRevision {

--- a/src/v1_14/api/apps/v1beta1/deployment.rs
+++ b/src/v1_14/api/apps/v1beta1/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_14/api/apps/v1beta1/scale.rs
+++ b/src/v1_14/api/apps/v1beta1/scale.rs
@@ -414,6 +414,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_14/api/apps/v1beta1/stateful_set.rs
+++ b/src/v1_14/api/apps/v1beta1/stateful_set.rs
@@ -699,6 +699,15 @@ impl crate::Metadata for StatefulSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StatefulSet {

--- a/src/v1_14/api/apps/v1beta2/controller_revision.rs
+++ b/src/v1_14/api/apps/v1beta2/controller_revision.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ControllerRevision {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ControllerRevision {

--- a/src/v1_14/api/apps/v1beta2/daemon_set.rs
+++ b/src/v1_14/api/apps/v1beta2/daemon_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for DaemonSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for DaemonSet {

--- a/src/v1_14/api/apps/v1beta2/deployment.rs
+++ b/src/v1_14/api/apps/v1beta2/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_14/api/apps/v1beta2/replica_set.rs
+++ b/src/v1_14/api/apps/v1beta2/replica_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicaSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicaSet {

--- a/src/v1_14/api/apps/v1beta2/scale.rs
+++ b/src/v1_14/api/apps/v1beta2/scale.rs
@@ -606,6 +606,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_14/api/apps/v1beta2/stateful_set.rs
+++ b/src/v1_14/api/apps/v1beta2/stateful_set.rs
@@ -699,6 +699,15 @@ impl crate::Metadata for StatefulSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StatefulSet {

--- a/src/v1_14/api/auditregistration/v1alpha1/audit_sink.rs
+++ b/src/v1_14/api/auditregistration/v1alpha1/audit_sink.rs
@@ -385,6 +385,15 @@ impl crate::Metadata for AuditSink {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for AuditSink {

--- a/src/v1_14/api/authentication/v1/token_review.rs
+++ b/src/v1_14/api/authentication/v1/token_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for TokenReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for TokenReview {

--- a/src/v1_14/api/authentication/v1beta1/token_review.rs
+++ b/src/v1_14/api/authentication/v1beta1/token_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for TokenReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for TokenReview {

--- a/src/v1_14/api/authorization/v1/local_subject_access_review.rs
+++ b/src/v1_14/api/authorization/v1/local_subject_access_review.rs
@@ -70,6 +70,15 @@ impl crate::Metadata for LocalSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LocalSubjectAccessReview {

--- a/src/v1_14/api/authorization/v1/self_subject_access_review.rs
+++ b/src/v1_14/api/authorization/v1/self_subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectAccessReview {

--- a/src/v1_14/api/authorization/v1/self_subject_rules_review.rs
+++ b/src/v1_14/api/authorization/v1/self_subject_rules_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectRulesReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectRulesReview {

--- a/src/v1_14/api/authorization/v1/subject_access_review.rs
+++ b/src/v1_14/api/authorization/v1/subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SubjectAccessReview {

--- a/src/v1_14/api/authorization/v1beta1/local_subject_access_review.rs
+++ b/src/v1_14/api/authorization/v1beta1/local_subject_access_review.rs
@@ -70,6 +70,15 @@ impl crate::Metadata for LocalSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LocalSubjectAccessReview {

--- a/src/v1_14/api/authorization/v1beta1/self_subject_access_review.rs
+++ b/src/v1_14/api/authorization/v1beta1/self_subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectAccessReview {

--- a/src/v1_14/api/authorization/v1beta1/self_subject_rules_review.rs
+++ b/src/v1_14/api/authorization/v1beta1/self_subject_rules_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectRulesReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectRulesReview {

--- a/src/v1_14/api/authorization/v1beta1/subject_access_review.rs
+++ b/src/v1_14/api/authorization/v1beta1/subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SubjectAccessReview {

--- a/src/v1_14/api/autoscaling/v1/horizontal_pod_autoscaler.rs
+++ b/src/v1_14/api/autoscaling/v1/horizontal_pod_autoscaler.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for HorizontalPodAutoscaler {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for HorizontalPodAutoscaler {

--- a/src/v1_14/api/autoscaling/v1/scale.rs
+++ b/src/v1_14/api/autoscaling/v1/scale.rs
@@ -798,6 +798,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_14/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
+++ b/src/v1_14/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for HorizontalPodAutoscaler {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for HorizontalPodAutoscaler {

--- a/src/v1_14/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
+++ b/src/v1_14/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for HorizontalPodAutoscaler {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for HorizontalPodAutoscaler {

--- a/src/v1_14/api/batch/v1/job.rs
+++ b/src/v1_14/api/batch/v1/job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Job {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Job {

--- a/src/v1_14/api/batch/v1beta1/cron_job.rs
+++ b/src/v1_14/api/batch/v1beta1/cron_job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for CronJob {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CronJob {

--- a/src/v1_14/api/batch/v2alpha1/cron_job.rs
+++ b/src/v1_14/api/batch/v2alpha1/cron_job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for CronJob {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CronJob {

--- a/src/v1_14/api/certificates/v1beta1/certificate_signing_request.rs
+++ b/src/v1_14/api/certificates/v1beta1/certificate_signing_request.rs
@@ -603,6 +603,15 @@ impl crate::Metadata for CertificateSigningRequest {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CertificateSigningRequest {

--- a/src/v1_14/api/coordination/v1/lease.rs
+++ b/src/v1_14/api/coordination/v1/lease.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for Lease {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Lease {

--- a/src/v1_14/api/coordination/v1beta1/lease.rs
+++ b/src/v1_14/api/coordination/v1beta1/lease.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for Lease {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Lease {

--- a/src/v1_14/api/core/v1/binding.rs
+++ b/src/v1_14/api/core/v1/binding.rs
@@ -115,6 +115,15 @@ impl crate::Metadata for Binding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Binding {

--- a/src/v1_14/api/core/v1/component_status.rs
+++ b/src/v1_14/api/core/v1/component_status.rs
@@ -183,6 +183,15 @@ impl crate::Metadata for ComponentStatus {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ComponentStatus {

--- a/src/v1_14/api/core/v1/config_map.rs
+++ b/src/v1_14/api/core/v1/config_map.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ConfigMap {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ConfigMap {

--- a/src/v1_14/api/core/v1/endpoints.rs
+++ b/src/v1_14/api/core/v1/endpoints.rs
@@ -513,6 +513,15 @@ impl crate::Metadata for Endpoints {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Endpoints {

--- a/src/v1_14/api/core/v1/event.rs
+++ b/src/v1_14/api/core/v1/event.rs
@@ -541,6 +541,15 @@ impl crate::Metadata for Event {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         Some(&self.metadata)
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        Some(&mut self.metadata)
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=metadata;
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Event {

--- a/src/v1_14/api/core/v1/limit_range.rs
+++ b/src/v1_14/api/core/v1/limit_range.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for LimitRange {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LimitRange {

--- a/src/v1_14/api/core/v1/namespace.rs
+++ b/src/v1_14/api/core/v1/namespace.rs
@@ -568,6 +568,15 @@ impl crate::Metadata for Namespace {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Namespace {

--- a/src/v1_14/api/core/v1/node.rs
+++ b/src/v1_14/api/core/v1/node.rs
@@ -1043,6 +1043,15 @@ impl crate::Metadata for Node {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Node {

--- a/src/v1_14/api/core/v1/persistent_volume.rs
+++ b/src/v1_14/api/core/v1/persistent_volume.rs
@@ -563,6 +563,15 @@ impl crate::Metadata for PersistentVolume {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PersistentVolume {

--- a/src/v1_14/api/core/v1/persistent_volume_claim.rs
+++ b/src/v1_14/api/core/v1/persistent_volume_claim.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for PersistentVolumeClaim {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PersistentVolumeClaim {

--- a/src/v1_14/api/core/v1/pod.rs
+++ b/src/v1_14/api/core/v1/pod.rs
@@ -1797,6 +1797,15 @@ impl crate::Metadata for Pod {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Pod {

--- a/src/v1_14/api/core/v1/pod_template.rs
+++ b/src/v1_14/api/core/v1/pod_template.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for PodTemplate {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodTemplate {

--- a/src/v1_14/api/core/v1/replication_controller.rs
+++ b/src/v1_14/api/core/v1/replication_controller.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicationController {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicationController {

--- a/src/v1_14/api/core/v1/resource_quota.rs
+++ b/src/v1_14/api/core/v1/resource_quota.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ResourceQuota {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ResourceQuota {

--- a/src/v1_14/api/core/v1/secret.rs
+++ b/src/v1_14/api/core/v1/secret.rs
@@ -508,6 +508,15 @@ impl crate::Metadata for Secret {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Secret {

--- a/src/v1_14/api/core/v1/service.rs
+++ b/src/v1_14/api/core/v1/service.rs
@@ -1194,6 +1194,15 @@ impl crate::Metadata for Service {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Service {

--- a/src/v1_14/api/core/v1/service_account.rs
+++ b/src/v1_14/api/core/v1/service_account.rs
@@ -508,6 +508,15 @@ impl crate::Metadata for ServiceAccount {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ServiceAccount {

--- a/src/v1_14/api/events/v1beta1/event.rs
+++ b/src/v1_14/api/events/v1beta1/event.rs
@@ -540,6 +540,15 @@ impl crate::Metadata for Event {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Event {

--- a/src/v1_14/api/extensions/v1beta1/daemon_set.rs
+++ b/src/v1_14/api/extensions/v1beta1/daemon_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for DaemonSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for DaemonSet {

--- a/src/v1_14/api/extensions/v1beta1/deployment.rs
+++ b/src/v1_14/api/extensions/v1beta1/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_14/api/extensions/v1beta1/ingress.rs
+++ b/src/v1_14/api/extensions/v1beta1/ingress.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Ingress {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Ingress {

--- a/src/v1_14/api/extensions/v1beta1/network_policy.rs
+++ b/src/v1_14/api/extensions/v1beta1/network_policy.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for NetworkPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for NetworkPolicy {

--- a/src/v1_14/api/extensions/v1beta1/pod_security_policy.rs
+++ b/src/v1_14/api/extensions/v1beta1/pod_security_policy.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for PodSecurityPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodSecurityPolicy {

--- a/src/v1_14/api/extensions/v1beta1/replica_set.rs
+++ b/src/v1_14/api/extensions/v1beta1/replica_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicaSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicaSet {

--- a/src/v1_14/api/extensions/v1beta1/scale.rs
+++ b/src/v1_14/api/extensions/v1beta1/scale.rs
@@ -606,6 +606,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_14/api/networking/v1/network_policy.rs
+++ b/src/v1_14/api/networking/v1/network_policy.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for NetworkPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for NetworkPolicy {

--- a/src/v1_14/api/networking/v1beta1/ingress.rs
+++ b/src/v1_14/api/networking/v1beta1/ingress.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Ingress {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Ingress {

--- a/src/v1_14/api/node/v1alpha1/runtime_class.rs
+++ b/src/v1_14/api/node/v1alpha1/runtime_class.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for RuntimeClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RuntimeClass {

--- a/src/v1_14/api/node/v1beta1/runtime_class.rs
+++ b/src/v1_14/api/node/v1beta1/runtime_class.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for RuntimeClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RuntimeClass {

--- a/src/v1_14/api/policy/v1beta1/eviction.rs
+++ b/src/v1_14/api/policy/v1beta1/eviction.rs
@@ -74,6 +74,15 @@ impl crate::Metadata for Eviction {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Eviction {

--- a/src/v1_14/api/policy/v1beta1/pod_disruption_budget.rs
+++ b/src/v1_14/api/policy/v1beta1/pod_disruption_budget.rs
@@ -696,6 +696,15 @@ impl crate::Metadata for PodDisruptionBudget {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodDisruptionBudget {

--- a/src/v1_14/api/policy/v1beta1/pod_security_policy.rs
+++ b/src/v1_14/api/policy/v1beta1/pod_security_policy.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for PodSecurityPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodSecurityPolicy {

--- a/src/v1_14/api/rbac/v1/cluster_role.rs
+++ b/src/v1_14/api/rbac/v1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_14/api/rbac/v1/cluster_role_binding.rs
+++ b/src/v1_14/api/rbac/v1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_14/api/rbac/v1/role.rs
+++ b/src/v1_14/api/rbac/v1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_14/api/rbac/v1/role_binding.rs
+++ b/src/v1_14/api/rbac/v1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_14/api/rbac/v1alpha1/cluster_role.rs
+++ b/src/v1_14/api/rbac/v1alpha1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_14/api/rbac/v1alpha1/cluster_role_binding.rs
+++ b/src/v1_14/api/rbac/v1alpha1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_14/api/rbac/v1alpha1/role.rs
+++ b/src/v1_14/api/rbac/v1alpha1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_14/api/rbac/v1alpha1/role_binding.rs
+++ b/src/v1_14/api/rbac/v1alpha1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_14/api/rbac/v1beta1/cluster_role.rs
+++ b/src/v1_14/api/rbac/v1beta1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_14/api/rbac/v1beta1/cluster_role_binding.rs
+++ b/src/v1_14/api/rbac/v1beta1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_14/api/rbac/v1beta1/role.rs
+++ b/src/v1_14/api/rbac/v1beta1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_14/api/rbac/v1beta1/role_binding.rs
+++ b/src/v1_14/api/rbac/v1beta1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_14/api/scheduling/v1/priority_class.rs
+++ b/src/v1_14/api/scheduling/v1/priority_class.rs
@@ -392,6 +392,15 @@ impl crate::Metadata for PriorityClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PriorityClass {

--- a/src/v1_14/api/scheduling/v1alpha1/priority_class.rs
+++ b/src/v1_14/api/scheduling/v1alpha1/priority_class.rs
@@ -392,6 +392,15 @@ impl crate::Metadata for PriorityClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PriorityClass {

--- a/src/v1_14/api/scheduling/v1beta1/priority_class.rs
+++ b/src/v1_14/api/scheduling/v1beta1/priority_class.rs
@@ -392,6 +392,15 @@ impl crate::Metadata for PriorityClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PriorityClass {

--- a/src/v1_14/api/settings/v1alpha1/pod_preset.rs
+++ b/src/v1_14/api/settings/v1alpha1/pod_preset.rs
@@ -500,6 +500,15 @@ impl crate::Metadata for PodPreset {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodPreset {

--- a/src/v1_14/api/storage/v1/storage_class.rs
+++ b/src/v1_14/api/storage/v1/storage_class.rs
@@ -406,6 +406,15 @@ impl crate::Metadata for StorageClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StorageClass {

--- a/src/v1_14/api/storage/v1/volume_attachment.rs
+++ b/src/v1_14/api/storage/v1/volume_attachment.rs
@@ -565,6 +565,15 @@ impl crate::Metadata for VolumeAttachment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for VolumeAttachment {

--- a/src/v1_14/api/storage/v1alpha1/volume_attachment.rs
+++ b/src/v1_14/api/storage/v1alpha1/volume_attachment.rs
@@ -391,6 +391,15 @@ impl crate::Metadata for VolumeAttachment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for VolumeAttachment {

--- a/src/v1_14/api/storage/v1beta1/csi_driver.rs
+++ b/src/v1_14/api/storage/v1beta1/csi_driver.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for CSIDriver {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CSIDriver {

--- a/src/v1_14/api/storage/v1beta1/csi_node.rs
+++ b/src/v1_14/api/storage/v1beta1/csi_node.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for CSINode {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CSINode {

--- a/src/v1_14/api/storage/v1beta1/storage_class.rs
+++ b/src/v1_14/api/storage/v1beta1/storage_class.rs
@@ -406,6 +406,15 @@ impl crate::Metadata for StorageClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StorageClass {

--- a/src/v1_14/api/storage/v1beta1/volume_attachment.rs
+++ b/src/v1_14/api/storage/v1beta1/volume_attachment.rs
@@ -391,6 +391,15 @@ impl crate::Metadata for VolumeAttachment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for VolumeAttachment {

--- a/src/v1_14/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
+++ b/src/v1_14/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for CustomResourceDefinition {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CustomResourceDefinition {

--- a/src/v1_14/apimachinery/pkg/apis/meta/v1/status.rs
+++ b/src/v1_14/apimachinery/pkg/apis/meta/v1/status.rs
@@ -35,6 +35,15 @@ impl crate::Metadata for Status {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Status {

--- a/src/v1_14/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
+++ b/src/v1_14/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for APIService {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for APIService {

--- a/src/v1_14/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
+++ b/src/v1_14/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for APIService {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for APIService {

--- a/src/v1_14/list.rs
+++ b/src/v1_14/list.rs
@@ -23,6 +23,15 @@ impl<T> crate::Metadata for List<T> where T: crate::ListableResource {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de, T> serde::Deserialize<'de> for List<T> where T: serde::Deserialize<'de> + crate::ListableResource {

--- a/src/v1_15/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
+++ b/src/v1_15/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for MutatingWebhookConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for MutatingWebhookConfiguration {

--- a/src/v1_15/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
+++ b/src/v1_15/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for ValidatingWebhookConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ValidatingWebhookConfiguration {

--- a/src/v1_15/api/apps/v1/controller_revision.rs
+++ b/src/v1_15/api/apps/v1/controller_revision.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ControllerRevision {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ControllerRevision {

--- a/src/v1_15/api/apps/v1/daemon_set.rs
+++ b/src/v1_15/api/apps/v1/daemon_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for DaemonSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for DaemonSet {

--- a/src/v1_15/api/apps/v1/deployment.rs
+++ b/src/v1_15/api/apps/v1/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_15/api/apps/v1/replica_set.rs
+++ b/src/v1_15/api/apps/v1/replica_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicaSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicaSet {

--- a/src/v1_15/api/apps/v1/stateful_set.rs
+++ b/src/v1_15/api/apps/v1/stateful_set.rs
@@ -699,6 +699,15 @@ impl crate::Metadata for StatefulSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StatefulSet {

--- a/src/v1_15/api/apps/v1beta1/controller_revision.rs
+++ b/src/v1_15/api/apps/v1beta1/controller_revision.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ControllerRevision {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ControllerRevision {

--- a/src/v1_15/api/apps/v1beta1/deployment.rs
+++ b/src/v1_15/api/apps/v1beta1/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_15/api/apps/v1beta1/scale.rs
+++ b/src/v1_15/api/apps/v1beta1/scale.rs
@@ -414,6 +414,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_15/api/apps/v1beta1/stateful_set.rs
+++ b/src/v1_15/api/apps/v1beta1/stateful_set.rs
@@ -699,6 +699,15 @@ impl crate::Metadata for StatefulSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StatefulSet {

--- a/src/v1_15/api/apps/v1beta2/controller_revision.rs
+++ b/src/v1_15/api/apps/v1beta2/controller_revision.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ControllerRevision {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ControllerRevision {

--- a/src/v1_15/api/apps/v1beta2/daemon_set.rs
+++ b/src/v1_15/api/apps/v1beta2/daemon_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for DaemonSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for DaemonSet {

--- a/src/v1_15/api/apps/v1beta2/deployment.rs
+++ b/src/v1_15/api/apps/v1beta2/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_15/api/apps/v1beta2/replica_set.rs
+++ b/src/v1_15/api/apps/v1beta2/replica_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicaSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicaSet {

--- a/src/v1_15/api/apps/v1beta2/scale.rs
+++ b/src/v1_15/api/apps/v1beta2/scale.rs
@@ -606,6 +606,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_15/api/apps/v1beta2/stateful_set.rs
+++ b/src/v1_15/api/apps/v1beta2/stateful_set.rs
@@ -699,6 +699,15 @@ impl crate::Metadata for StatefulSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StatefulSet {

--- a/src/v1_15/api/auditregistration/v1alpha1/audit_sink.rs
+++ b/src/v1_15/api/auditregistration/v1alpha1/audit_sink.rs
@@ -385,6 +385,15 @@ impl crate::Metadata for AuditSink {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for AuditSink {

--- a/src/v1_15/api/authentication/v1/token_review.rs
+++ b/src/v1_15/api/authentication/v1/token_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for TokenReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for TokenReview {

--- a/src/v1_15/api/authentication/v1beta1/token_review.rs
+++ b/src/v1_15/api/authentication/v1beta1/token_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for TokenReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for TokenReview {

--- a/src/v1_15/api/authorization/v1/local_subject_access_review.rs
+++ b/src/v1_15/api/authorization/v1/local_subject_access_review.rs
@@ -70,6 +70,15 @@ impl crate::Metadata for LocalSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LocalSubjectAccessReview {

--- a/src/v1_15/api/authorization/v1/self_subject_access_review.rs
+++ b/src/v1_15/api/authorization/v1/self_subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectAccessReview {

--- a/src/v1_15/api/authorization/v1/self_subject_rules_review.rs
+++ b/src/v1_15/api/authorization/v1/self_subject_rules_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectRulesReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectRulesReview {

--- a/src/v1_15/api/authorization/v1/subject_access_review.rs
+++ b/src/v1_15/api/authorization/v1/subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SubjectAccessReview {

--- a/src/v1_15/api/authorization/v1beta1/local_subject_access_review.rs
+++ b/src/v1_15/api/authorization/v1beta1/local_subject_access_review.rs
@@ -70,6 +70,15 @@ impl crate::Metadata for LocalSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LocalSubjectAccessReview {

--- a/src/v1_15/api/authorization/v1beta1/self_subject_access_review.rs
+++ b/src/v1_15/api/authorization/v1beta1/self_subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectAccessReview {

--- a/src/v1_15/api/authorization/v1beta1/self_subject_rules_review.rs
+++ b/src/v1_15/api/authorization/v1beta1/self_subject_rules_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectRulesReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectRulesReview {

--- a/src/v1_15/api/authorization/v1beta1/subject_access_review.rs
+++ b/src/v1_15/api/authorization/v1beta1/subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SubjectAccessReview {

--- a/src/v1_15/api/autoscaling/v1/horizontal_pod_autoscaler.rs
+++ b/src/v1_15/api/autoscaling/v1/horizontal_pod_autoscaler.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for HorizontalPodAutoscaler {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for HorizontalPodAutoscaler {

--- a/src/v1_15/api/autoscaling/v1/scale.rs
+++ b/src/v1_15/api/autoscaling/v1/scale.rs
@@ -798,6 +798,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_15/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
+++ b/src/v1_15/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for HorizontalPodAutoscaler {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for HorizontalPodAutoscaler {

--- a/src/v1_15/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
+++ b/src/v1_15/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for HorizontalPodAutoscaler {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for HorizontalPodAutoscaler {

--- a/src/v1_15/api/batch/v1/job.rs
+++ b/src/v1_15/api/batch/v1/job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Job {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Job {

--- a/src/v1_15/api/batch/v1beta1/cron_job.rs
+++ b/src/v1_15/api/batch/v1beta1/cron_job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for CronJob {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CronJob {

--- a/src/v1_15/api/batch/v2alpha1/cron_job.rs
+++ b/src/v1_15/api/batch/v2alpha1/cron_job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for CronJob {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CronJob {

--- a/src/v1_15/api/certificates/v1beta1/certificate_signing_request.rs
+++ b/src/v1_15/api/certificates/v1beta1/certificate_signing_request.rs
@@ -603,6 +603,15 @@ impl crate::Metadata for CertificateSigningRequest {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CertificateSigningRequest {

--- a/src/v1_15/api/coordination/v1/lease.rs
+++ b/src/v1_15/api/coordination/v1/lease.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for Lease {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Lease {

--- a/src/v1_15/api/coordination/v1beta1/lease.rs
+++ b/src/v1_15/api/coordination/v1beta1/lease.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for Lease {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Lease {

--- a/src/v1_15/api/core/v1/binding.rs
+++ b/src/v1_15/api/core/v1/binding.rs
@@ -115,6 +115,15 @@ impl crate::Metadata for Binding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Binding {

--- a/src/v1_15/api/core/v1/component_status.rs
+++ b/src/v1_15/api/core/v1/component_status.rs
@@ -183,6 +183,15 @@ impl crate::Metadata for ComponentStatus {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ComponentStatus {

--- a/src/v1_15/api/core/v1/config_map.rs
+++ b/src/v1_15/api/core/v1/config_map.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ConfigMap {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ConfigMap {

--- a/src/v1_15/api/core/v1/endpoints.rs
+++ b/src/v1_15/api/core/v1/endpoints.rs
@@ -513,6 +513,15 @@ impl crate::Metadata for Endpoints {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Endpoints {

--- a/src/v1_15/api/core/v1/event.rs
+++ b/src/v1_15/api/core/v1/event.rs
@@ -541,6 +541,15 @@ impl crate::Metadata for Event {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         Some(&self.metadata)
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        Some(&mut self.metadata)
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=metadata;
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Event {

--- a/src/v1_15/api/core/v1/limit_range.rs
+++ b/src/v1_15/api/core/v1/limit_range.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for LimitRange {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LimitRange {

--- a/src/v1_15/api/core/v1/namespace.rs
+++ b/src/v1_15/api/core/v1/namespace.rs
@@ -568,6 +568,15 @@ impl crate::Metadata for Namespace {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Namespace {

--- a/src/v1_15/api/core/v1/node.rs
+++ b/src/v1_15/api/core/v1/node.rs
@@ -1043,6 +1043,15 @@ impl crate::Metadata for Node {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Node {

--- a/src/v1_15/api/core/v1/persistent_volume.rs
+++ b/src/v1_15/api/core/v1/persistent_volume.rs
@@ -563,6 +563,15 @@ impl crate::Metadata for PersistentVolume {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PersistentVolume {

--- a/src/v1_15/api/core/v1/persistent_volume_claim.rs
+++ b/src/v1_15/api/core/v1/persistent_volume_claim.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for PersistentVolumeClaim {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PersistentVolumeClaim {

--- a/src/v1_15/api/core/v1/pod.rs
+++ b/src/v1_15/api/core/v1/pod.rs
@@ -1797,6 +1797,15 @@ impl crate::Metadata for Pod {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Pod {

--- a/src/v1_15/api/core/v1/pod_template.rs
+++ b/src/v1_15/api/core/v1/pod_template.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for PodTemplate {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodTemplate {

--- a/src/v1_15/api/core/v1/replication_controller.rs
+++ b/src/v1_15/api/core/v1/replication_controller.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicationController {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicationController {

--- a/src/v1_15/api/core/v1/resource_quota.rs
+++ b/src/v1_15/api/core/v1/resource_quota.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ResourceQuota {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ResourceQuota {

--- a/src/v1_15/api/core/v1/secret.rs
+++ b/src/v1_15/api/core/v1/secret.rs
@@ -508,6 +508,15 @@ impl crate::Metadata for Secret {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Secret {

--- a/src/v1_15/api/core/v1/service.rs
+++ b/src/v1_15/api/core/v1/service.rs
@@ -1194,6 +1194,15 @@ impl crate::Metadata for Service {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Service {

--- a/src/v1_15/api/core/v1/service_account.rs
+++ b/src/v1_15/api/core/v1/service_account.rs
@@ -508,6 +508,15 @@ impl crate::Metadata for ServiceAccount {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ServiceAccount {

--- a/src/v1_15/api/events/v1beta1/event.rs
+++ b/src/v1_15/api/events/v1beta1/event.rs
@@ -540,6 +540,15 @@ impl crate::Metadata for Event {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Event {

--- a/src/v1_15/api/extensions/v1beta1/daemon_set.rs
+++ b/src/v1_15/api/extensions/v1beta1/daemon_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for DaemonSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for DaemonSet {

--- a/src/v1_15/api/extensions/v1beta1/deployment.rs
+++ b/src/v1_15/api/extensions/v1beta1/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_15/api/extensions/v1beta1/ingress.rs
+++ b/src/v1_15/api/extensions/v1beta1/ingress.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Ingress {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Ingress {

--- a/src/v1_15/api/extensions/v1beta1/network_policy.rs
+++ b/src/v1_15/api/extensions/v1beta1/network_policy.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for NetworkPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for NetworkPolicy {

--- a/src/v1_15/api/extensions/v1beta1/pod_security_policy.rs
+++ b/src/v1_15/api/extensions/v1beta1/pod_security_policy.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for PodSecurityPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodSecurityPolicy {

--- a/src/v1_15/api/extensions/v1beta1/replica_set.rs
+++ b/src/v1_15/api/extensions/v1beta1/replica_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicaSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicaSet {

--- a/src/v1_15/api/extensions/v1beta1/scale.rs
+++ b/src/v1_15/api/extensions/v1beta1/scale.rs
@@ -606,6 +606,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_15/api/networking/v1/network_policy.rs
+++ b/src/v1_15/api/networking/v1/network_policy.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for NetworkPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for NetworkPolicy {

--- a/src/v1_15/api/networking/v1beta1/ingress.rs
+++ b/src/v1_15/api/networking/v1beta1/ingress.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Ingress {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Ingress {

--- a/src/v1_15/api/node/v1alpha1/runtime_class.rs
+++ b/src/v1_15/api/node/v1alpha1/runtime_class.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for RuntimeClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RuntimeClass {

--- a/src/v1_15/api/node/v1beta1/runtime_class.rs
+++ b/src/v1_15/api/node/v1beta1/runtime_class.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for RuntimeClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RuntimeClass {

--- a/src/v1_15/api/policy/v1beta1/eviction.rs
+++ b/src/v1_15/api/policy/v1beta1/eviction.rs
@@ -74,6 +74,15 @@ impl crate::Metadata for Eviction {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Eviction {

--- a/src/v1_15/api/policy/v1beta1/pod_disruption_budget.rs
+++ b/src/v1_15/api/policy/v1beta1/pod_disruption_budget.rs
@@ -696,6 +696,15 @@ impl crate::Metadata for PodDisruptionBudget {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodDisruptionBudget {

--- a/src/v1_15/api/policy/v1beta1/pod_security_policy.rs
+++ b/src/v1_15/api/policy/v1beta1/pod_security_policy.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for PodSecurityPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodSecurityPolicy {

--- a/src/v1_15/api/rbac/v1/cluster_role.rs
+++ b/src/v1_15/api/rbac/v1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_15/api/rbac/v1/cluster_role_binding.rs
+++ b/src/v1_15/api/rbac/v1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_15/api/rbac/v1/role.rs
+++ b/src/v1_15/api/rbac/v1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_15/api/rbac/v1/role_binding.rs
+++ b/src/v1_15/api/rbac/v1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_15/api/rbac/v1alpha1/cluster_role.rs
+++ b/src/v1_15/api/rbac/v1alpha1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_15/api/rbac/v1alpha1/cluster_role_binding.rs
+++ b/src/v1_15/api/rbac/v1alpha1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_15/api/rbac/v1alpha1/role.rs
+++ b/src/v1_15/api/rbac/v1alpha1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_15/api/rbac/v1alpha1/role_binding.rs
+++ b/src/v1_15/api/rbac/v1alpha1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_15/api/rbac/v1beta1/cluster_role.rs
+++ b/src/v1_15/api/rbac/v1beta1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_15/api/rbac/v1beta1/cluster_role_binding.rs
+++ b/src/v1_15/api/rbac/v1beta1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_15/api/rbac/v1beta1/role.rs
+++ b/src/v1_15/api/rbac/v1beta1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_15/api/rbac/v1beta1/role_binding.rs
+++ b/src/v1_15/api/rbac/v1beta1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_15/api/scheduling/v1/priority_class.rs
+++ b/src/v1_15/api/scheduling/v1/priority_class.rs
@@ -395,6 +395,15 @@ impl crate::Metadata for PriorityClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PriorityClass {

--- a/src/v1_15/api/scheduling/v1alpha1/priority_class.rs
+++ b/src/v1_15/api/scheduling/v1alpha1/priority_class.rs
@@ -395,6 +395,15 @@ impl crate::Metadata for PriorityClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PriorityClass {

--- a/src/v1_15/api/scheduling/v1beta1/priority_class.rs
+++ b/src/v1_15/api/scheduling/v1beta1/priority_class.rs
@@ -395,6 +395,15 @@ impl crate::Metadata for PriorityClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PriorityClass {

--- a/src/v1_15/api/settings/v1alpha1/pod_preset.rs
+++ b/src/v1_15/api/settings/v1alpha1/pod_preset.rs
@@ -500,6 +500,15 @@ impl crate::Metadata for PodPreset {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodPreset {

--- a/src/v1_15/api/storage/v1/storage_class.rs
+++ b/src/v1_15/api/storage/v1/storage_class.rs
@@ -406,6 +406,15 @@ impl crate::Metadata for StorageClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StorageClass {

--- a/src/v1_15/api/storage/v1/volume_attachment.rs
+++ b/src/v1_15/api/storage/v1/volume_attachment.rs
@@ -565,6 +565,15 @@ impl crate::Metadata for VolumeAttachment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for VolumeAttachment {

--- a/src/v1_15/api/storage/v1alpha1/volume_attachment.rs
+++ b/src/v1_15/api/storage/v1alpha1/volume_attachment.rs
@@ -391,6 +391,15 @@ impl crate::Metadata for VolumeAttachment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for VolumeAttachment {

--- a/src/v1_15/api/storage/v1beta1/csi_driver.rs
+++ b/src/v1_15/api/storage/v1beta1/csi_driver.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for CSIDriver {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CSIDriver {

--- a/src/v1_15/api/storage/v1beta1/csi_node.rs
+++ b/src/v1_15/api/storage/v1beta1/csi_node.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for CSINode {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CSINode {

--- a/src/v1_15/api/storage/v1beta1/storage_class.rs
+++ b/src/v1_15/api/storage/v1beta1/storage_class.rs
@@ -406,6 +406,15 @@ impl crate::Metadata for StorageClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StorageClass {

--- a/src/v1_15/api/storage/v1beta1/volume_attachment.rs
+++ b/src/v1_15/api/storage/v1beta1/volume_attachment.rs
@@ -391,6 +391,15 @@ impl crate::Metadata for VolumeAttachment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for VolumeAttachment {

--- a/src/v1_15/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
+++ b/src/v1_15/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for CustomResourceDefinition {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CustomResourceDefinition {

--- a/src/v1_15/apimachinery/pkg/apis/meta/v1/status.rs
+++ b/src/v1_15/apimachinery/pkg/apis/meta/v1/status.rs
@@ -35,6 +35,15 @@ impl crate::Metadata for Status {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Status {

--- a/src/v1_15/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
+++ b/src/v1_15/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for APIService {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for APIService {

--- a/src/v1_15/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
+++ b/src/v1_15/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for APIService {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for APIService {

--- a/src/v1_15/list.rs
+++ b/src/v1_15/list.rs
@@ -23,6 +23,15 @@ impl<T> crate::Metadata for List<T> where T: crate::ListableResource {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de, T> serde::Deserialize<'de> for List<T> where T: serde::Deserialize<'de> + crate::ListableResource {

--- a/src/v1_16/api/admissionregistration/v1/mutating_webhook_configuration.rs
+++ b/src/v1_16/api/admissionregistration/v1/mutating_webhook_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for MutatingWebhookConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for MutatingWebhookConfiguration {

--- a/src/v1_16/api/admissionregistration/v1/validating_webhook_configuration.rs
+++ b/src/v1_16/api/admissionregistration/v1/validating_webhook_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for ValidatingWebhookConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ValidatingWebhookConfiguration {

--- a/src/v1_16/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
+++ b/src/v1_16/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for MutatingWebhookConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for MutatingWebhookConfiguration {

--- a/src/v1_16/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
+++ b/src/v1_16/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for ValidatingWebhookConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ValidatingWebhookConfiguration {

--- a/src/v1_16/api/apps/v1/controller_revision.rs
+++ b/src/v1_16/api/apps/v1/controller_revision.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ControllerRevision {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ControllerRevision {

--- a/src/v1_16/api/apps/v1/daemon_set.rs
+++ b/src/v1_16/api/apps/v1/daemon_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for DaemonSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for DaemonSet {

--- a/src/v1_16/api/apps/v1/deployment.rs
+++ b/src/v1_16/api/apps/v1/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_16/api/apps/v1/replica_set.rs
+++ b/src/v1_16/api/apps/v1/replica_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicaSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicaSet {

--- a/src/v1_16/api/apps/v1/stateful_set.rs
+++ b/src/v1_16/api/apps/v1/stateful_set.rs
@@ -699,6 +699,15 @@ impl crate::Metadata for StatefulSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StatefulSet {

--- a/src/v1_16/api/apps/v1beta1/controller_revision.rs
+++ b/src/v1_16/api/apps/v1beta1/controller_revision.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ControllerRevision {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ControllerRevision {

--- a/src/v1_16/api/apps/v1beta1/deployment.rs
+++ b/src/v1_16/api/apps/v1beta1/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_16/api/apps/v1beta1/scale.rs
+++ b/src/v1_16/api/apps/v1beta1/scale.rs
@@ -414,6 +414,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_16/api/apps/v1beta1/stateful_set.rs
+++ b/src/v1_16/api/apps/v1beta1/stateful_set.rs
@@ -699,6 +699,15 @@ impl crate::Metadata for StatefulSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StatefulSet {

--- a/src/v1_16/api/apps/v1beta2/controller_revision.rs
+++ b/src/v1_16/api/apps/v1beta2/controller_revision.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ControllerRevision {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ControllerRevision {

--- a/src/v1_16/api/apps/v1beta2/daemon_set.rs
+++ b/src/v1_16/api/apps/v1beta2/daemon_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for DaemonSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for DaemonSet {

--- a/src/v1_16/api/apps/v1beta2/deployment.rs
+++ b/src/v1_16/api/apps/v1beta2/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_16/api/apps/v1beta2/replica_set.rs
+++ b/src/v1_16/api/apps/v1beta2/replica_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicaSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicaSet {

--- a/src/v1_16/api/apps/v1beta2/scale.rs
+++ b/src/v1_16/api/apps/v1beta2/scale.rs
@@ -606,6 +606,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_16/api/apps/v1beta2/stateful_set.rs
+++ b/src/v1_16/api/apps/v1beta2/stateful_set.rs
@@ -699,6 +699,15 @@ impl crate::Metadata for StatefulSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StatefulSet {

--- a/src/v1_16/api/auditregistration/v1alpha1/audit_sink.rs
+++ b/src/v1_16/api/auditregistration/v1alpha1/audit_sink.rs
@@ -385,6 +385,15 @@ impl crate::Metadata for AuditSink {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for AuditSink {

--- a/src/v1_16/api/authentication/v1/token_request.rs
+++ b/src/v1_16/api/authentication/v1/token_request.rs
@@ -74,6 +74,15 @@ impl crate::Metadata for TokenRequest {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for TokenRequest {

--- a/src/v1_16/api/authentication/v1/token_review.rs
+++ b/src/v1_16/api/authentication/v1/token_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for TokenReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for TokenReview {

--- a/src/v1_16/api/authentication/v1beta1/token_review.rs
+++ b/src/v1_16/api/authentication/v1beta1/token_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for TokenReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for TokenReview {

--- a/src/v1_16/api/authorization/v1/local_subject_access_review.rs
+++ b/src/v1_16/api/authorization/v1/local_subject_access_review.rs
@@ -70,6 +70,15 @@ impl crate::Metadata for LocalSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LocalSubjectAccessReview {

--- a/src/v1_16/api/authorization/v1/self_subject_access_review.rs
+++ b/src/v1_16/api/authorization/v1/self_subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectAccessReview {

--- a/src/v1_16/api/authorization/v1/self_subject_rules_review.rs
+++ b/src/v1_16/api/authorization/v1/self_subject_rules_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectRulesReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectRulesReview {

--- a/src/v1_16/api/authorization/v1/subject_access_review.rs
+++ b/src/v1_16/api/authorization/v1/subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SubjectAccessReview {

--- a/src/v1_16/api/authorization/v1beta1/local_subject_access_review.rs
+++ b/src/v1_16/api/authorization/v1beta1/local_subject_access_review.rs
@@ -70,6 +70,15 @@ impl crate::Metadata for LocalSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LocalSubjectAccessReview {

--- a/src/v1_16/api/authorization/v1beta1/self_subject_access_review.rs
+++ b/src/v1_16/api/authorization/v1beta1/self_subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectAccessReview {

--- a/src/v1_16/api/authorization/v1beta1/self_subject_rules_review.rs
+++ b/src/v1_16/api/authorization/v1beta1/self_subject_rules_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectRulesReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectRulesReview {

--- a/src/v1_16/api/authorization/v1beta1/subject_access_review.rs
+++ b/src/v1_16/api/authorization/v1beta1/subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SubjectAccessReview {

--- a/src/v1_16/api/autoscaling/v1/horizontal_pod_autoscaler.rs
+++ b/src/v1_16/api/autoscaling/v1/horizontal_pod_autoscaler.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for HorizontalPodAutoscaler {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for HorizontalPodAutoscaler {

--- a/src/v1_16/api/autoscaling/v1/scale.rs
+++ b/src/v1_16/api/autoscaling/v1/scale.rs
@@ -798,6 +798,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_16/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
+++ b/src/v1_16/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for HorizontalPodAutoscaler {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for HorizontalPodAutoscaler {

--- a/src/v1_16/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
+++ b/src/v1_16/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for HorizontalPodAutoscaler {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for HorizontalPodAutoscaler {

--- a/src/v1_16/api/batch/v1/job.rs
+++ b/src/v1_16/api/batch/v1/job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Job {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Job {

--- a/src/v1_16/api/batch/v1beta1/cron_job.rs
+++ b/src/v1_16/api/batch/v1beta1/cron_job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for CronJob {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CronJob {

--- a/src/v1_16/api/batch/v2alpha1/cron_job.rs
+++ b/src/v1_16/api/batch/v2alpha1/cron_job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for CronJob {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CronJob {

--- a/src/v1_16/api/certificates/v1beta1/certificate_signing_request.rs
+++ b/src/v1_16/api/certificates/v1beta1/certificate_signing_request.rs
@@ -603,6 +603,15 @@ impl crate::Metadata for CertificateSigningRequest {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CertificateSigningRequest {

--- a/src/v1_16/api/coordination/v1/lease.rs
+++ b/src/v1_16/api/coordination/v1/lease.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for Lease {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Lease {

--- a/src/v1_16/api/coordination/v1beta1/lease.rs
+++ b/src/v1_16/api/coordination/v1beta1/lease.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for Lease {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Lease {

--- a/src/v1_16/api/core/v1/binding.rs
+++ b/src/v1_16/api/core/v1/binding.rs
@@ -115,6 +115,15 @@ impl crate::Metadata for Binding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Binding {

--- a/src/v1_16/api/core/v1/component_status.rs
+++ b/src/v1_16/api/core/v1/component_status.rs
@@ -183,6 +183,15 @@ impl crate::Metadata for ComponentStatus {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ComponentStatus {

--- a/src/v1_16/api/core/v1/config_map.rs
+++ b/src/v1_16/api/core/v1/config_map.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ConfigMap {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ConfigMap {

--- a/src/v1_16/api/core/v1/endpoints.rs
+++ b/src/v1_16/api/core/v1/endpoints.rs
@@ -513,6 +513,15 @@ impl crate::Metadata for Endpoints {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Endpoints {

--- a/src/v1_16/api/core/v1/event.rs
+++ b/src/v1_16/api/core/v1/event.rs
@@ -541,6 +541,15 @@ impl crate::Metadata for Event {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         Some(&self.metadata)
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        Some(&mut self.metadata)
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=metadata;
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Event {

--- a/src/v1_16/api/core/v1/limit_range.rs
+++ b/src/v1_16/api/core/v1/limit_range.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for LimitRange {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LimitRange {

--- a/src/v1_16/api/core/v1/namespace.rs
+++ b/src/v1_16/api/core/v1/namespace.rs
@@ -568,6 +568,15 @@ impl crate::Metadata for Namespace {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Namespace {

--- a/src/v1_16/api/core/v1/node.rs
+++ b/src/v1_16/api/core/v1/node.rs
@@ -1043,6 +1043,15 @@ impl crate::Metadata for Node {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Node {

--- a/src/v1_16/api/core/v1/persistent_volume.rs
+++ b/src/v1_16/api/core/v1/persistent_volume.rs
@@ -563,6 +563,15 @@ impl crate::Metadata for PersistentVolume {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PersistentVolume {

--- a/src/v1_16/api/core/v1/persistent_volume_claim.rs
+++ b/src/v1_16/api/core/v1/persistent_volume_claim.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for PersistentVolumeClaim {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PersistentVolumeClaim {

--- a/src/v1_16/api/core/v1/pod.rs
+++ b/src/v1_16/api/core/v1/pod.rs
@@ -1797,6 +1797,15 @@ impl crate::Metadata for Pod {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Pod {

--- a/src/v1_16/api/core/v1/pod_template.rs
+++ b/src/v1_16/api/core/v1/pod_template.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for PodTemplate {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodTemplate {

--- a/src/v1_16/api/core/v1/replication_controller.rs
+++ b/src/v1_16/api/core/v1/replication_controller.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicationController {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicationController {

--- a/src/v1_16/api/core/v1/resource_quota.rs
+++ b/src/v1_16/api/core/v1/resource_quota.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ResourceQuota {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ResourceQuota {

--- a/src/v1_16/api/core/v1/secret.rs
+++ b/src/v1_16/api/core/v1/secret.rs
@@ -508,6 +508,15 @@ impl crate::Metadata for Secret {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Secret {

--- a/src/v1_16/api/core/v1/service.rs
+++ b/src/v1_16/api/core/v1/service.rs
@@ -1194,6 +1194,15 @@ impl crate::Metadata for Service {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Service {

--- a/src/v1_16/api/core/v1/service_account.rs
+++ b/src/v1_16/api/core/v1/service_account.rs
@@ -508,6 +508,15 @@ impl crate::Metadata for ServiceAccount {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ServiceAccount {

--- a/src/v1_16/api/discovery/v1alpha1/endpoint_slice.rs
+++ b/src/v1_16/api/discovery/v1alpha1/endpoint_slice.rs
@@ -508,6 +508,15 @@ impl crate::Metadata for EndpointSlice {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for EndpointSlice {

--- a/src/v1_16/api/events/v1beta1/event.rs
+++ b/src/v1_16/api/events/v1beta1/event.rs
@@ -540,6 +540,15 @@ impl crate::Metadata for Event {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Event {

--- a/src/v1_16/api/extensions/v1beta1/daemon_set.rs
+++ b/src/v1_16/api/extensions/v1beta1/daemon_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for DaemonSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for DaemonSet {

--- a/src/v1_16/api/extensions/v1beta1/deployment.rs
+++ b/src/v1_16/api/extensions/v1beta1/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_16/api/extensions/v1beta1/ingress.rs
+++ b/src/v1_16/api/extensions/v1beta1/ingress.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Ingress {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Ingress {

--- a/src/v1_16/api/extensions/v1beta1/network_policy.rs
+++ b/src/v1_16/api/extensions/v1beta1/network_policy.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for NetworkPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for NetworkPolicy {

--- a/src/v1_16/api/extensions/v1beta1/pod_security_policy.rs
+++ b/src/v1_16/api/extensions/v1beta1/pod_security_policy.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for PodSecurityPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodSecurityPolicy {

--- a/src/v1_16/api/extensions/v1beta1/replica_set.rs
+++ b/src/v1_16/api/extensions/v1beta1/replica_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicaSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicaSet {

--- a/src/v1_16/api/extensions/v1beta1/scale.rs
+++ b/src/v1_16/api/extensions/v1beta1/scale.rs
@@ -606,6 +606,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_16/api/networking/v1/network_policy.rs
+++ b/src/v1_16/api/networking/v1/network_policy.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for NetworkPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for NetworkPolicy {

--- a/src/v1_16/api/networking/v1beta1/ingress.rs
+++ b/src/v1_16/api/networking/v1beta1/ingress.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Ingress {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Ingress {

--- a/src/v1_16/api/node/v1alpha1/runtime_class.rs
+++ b/src/v1_16/api/node/v1alpha1/runtime_class.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for RuntimeClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RuntimeClass {

--- a/src/v1_16/api/node/v1beta1/runtime_class.rs
+++ b/src/v1_16/api/node/v1beta1/runtime_class.rs
@@ -392,6 +392,15 @@ impl crate::Metadata for RuntimeClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RuntimeClass {

--- a/src/v1_16/api/policy/v1beta1/eviction.rs
+++ b/src/v1_16/api/policy/v1beta1/eviction.rs
@@ -74,6 +74,15 @@ impl crate::Metadata for Eviction {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Eviction {

--- a/src/v1_16/api/policy/v1beta1/pod_disruption_budget.rs
+++ b/src/v1_16/api/policy/v1beta1/pod_disruption_budget.rs
@@ -696,6 +696,15 @@ impl crate::Metadata for PodDisruptionBudget {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodDisruptionBudget {

--- a/src/v1_16/api/policy/v1beta1/pod_security_policy.rs
+++ b/src/v1_16/api/policy/v1beta1/pod_security_policy.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for PodSecurityPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodSecurityPolicy {

--- a/src/v1_16/api/rbac/v1/cluster_role.rs
+++ b/src/v1_16/api/rbac/v1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_16/api/rbac/v1/cluster_role_binding.rs
+++ b/src/v1_16/api/rbac/v1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_16/api/rbac/v1/role.rs
+++ b/src/v1_16/api/rbac/v1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_16/api/rbac/v1/role_binding.rs
+++ b/src/v1_16/api/rbac/v1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_16/api/rbac/v1alpha1/cluster_role.rs
+++ b/src/v1_16/api/rbac/v1alpha1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_16/api/rbac/v1alpha1/cluster_role_binding.rs
+++ b/src/v1_16/api/rbac/v1alpha1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_16/api/rbac/v1alpha1/role.rs
+++ b/src/v1_16/api/rbac/v1alpha1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_16/api/rbac/v1alpha1/role_binding.rs
+++ b/src/v1_16/api/rbac/v1alpha1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_16/api/rbac/v1beta1/cluster_role.rs
+++ b/src/v1_16/api/rbac/v1beta1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_16/api/rbac/v1beta1/cluster_role_binding.rs
+++ b/src/v1_16/api/rbac/v1beta1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_16/api/rbac/v1beta1/role.rs
+++ b/src/v1_16/api/rbac/v1beta1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_16/api/rbac/v1beta1/role_binding.rs
+++ b/src/v1_16/api/rbac/v1beta1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_16/api/scheduling/v1/priority_class.rs
+++ b/src/v1_16/api/scheduling/v1/priority_class.rs
@@ -395,6 +395,15 @@ impl crate::Metadata for PriorityClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PriorityClass {

--- a/src/v1_16/api/scheduling/v1alpha1/priority_class.rs
+++ b/src/v1_16/api/scheduling/v1alpha1/priority_class.rs
@@ -395,6 +395,15 @@ impl crate::Metadata for PriorityClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PriorityClass {

--- a/src/v1_16/api/scheduling/v1beta1/priority_class.rs
+++ b/src/v1_16/api/scheduling/v1beta1/priority_class.rs
@@ -395,6 +395,15 @@ impl crate::Metadata for PriorityClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PriorityClass {

--- a/src/v1_16/api/settings/v1alpha1/pod_preset.rs
+++ b/src/v1_16/api/settings/v1alpha1/pod_preset.rs
@@ -500,6 +500,15 @@ impl crate::Metadata for PodPreset {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodPreset {

--- a/src/v1_16/api/storage/v1/storage_class.rs
+++ b/src/v1_16/api/storage/v1/storage_class.rs
@@ -406,6 +406,15 @@ impl crate::Metadata for StorageClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StorageClass {

--- a/src/v1_16/api/storage/v1/volume_attachment.rs
+++ b/src/v1_16/api/storage/v1/volume_attachment.rs
@@ -565,6 +565,15 @@ impl crate::Metadata for VolumeAttachment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for VolumeAttachment {

--- a/src/v1_16/api/storage/v1alpha1/volume_attachment.rs
+++ b/src/v1_16/api/storage/v1alpha1/volume_attachment.rs
@@ -391,6 +391,15 @@ impl crate::Metadata for VolumeAttachment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for VolumeAttachment {

--- a/src/v1_16/api/storage/v1beta1/csi_driver.rs
+++ b/src/v1_16/api/storage/v1beta1/csi_driver.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for CSIDriver {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CSIDriver {

--- a/src/v1_16/api/storage/v1beta1/csi_node.rs
+++ b/src/v1_16/api/storage/v1beta1/csi_node.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for CSINode {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CSINode {

--- a/src/v1_16/api/storage/v1beta1/storage_class.rs
+++ b/src/v1_16/api/storage/v1beta1/storage_class.rs
@@ -406,6 +406,15 @@ impl crate::Metadata for StorageClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StorageClass {

--- a/src/v1_16/api/storage/v1beta1/volume_attachment.rs
+++ b/src/v1_16/api/storage/v1beta1/volume_attachment.rs
@@ -391,6 +391,15 @@ impl crate::Metadata for VolumeAttachment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for VolumeAttachment {

--- a/src/v1_16/apiextensions_apiserver/pkg/apis/apiextensions/v1/custom_resource_definition.rs
+++ b/src/v1_16/apiextensions_apiserver/pkg/apis/apiextensions/v1/custom_resource_definition.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for CustomResourceDefinition {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CustomResourceDefinition {

--- a/src/v1_16/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
+++ b/src/v1_16/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for CustomResourceDefinition {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CustomResourceDefinition {

--- a/src/v1_16/apimachinery/pkg/apis/meta/v1/status.rs
+++ b/src/v1_16/apimachinery/pkg/apis/meta/v1/status.rs
@@ -35,6 +35,15 @@ impl crate::Metadata for Status {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Status {

--- a/src/v1_16/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
+++ b/src/v1_16/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for APIService {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for APIService {

--- a/src/v1_16/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
+++ b/src/v1_16/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for APIService {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for APIService {

--- a/src/v1_16/list.rs
+++ b/src/v1_16/list.rs
@@ -23,6 +23,15 @@ impl<T> crate::Metadata for List<T> where T: crate::ListableResource {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de, T> serde::Deserialize<'de> for List<T> where T: serde::Deserialize<'de> + crate::ListableResource {

--- a/src/v1_17/api/admissionregistration/v1/mutating_webhook_configuration.rs
+++ b/src/v1_17/api/admissionregistration/v1/mutating_webhook_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for MutatingWebhookConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for MutatingWebhookConfiguration {

--- a/src/v1_17/api/admissionregistration/v1/validating_webhook_configuration.rs
+++ b/src/v1_17/api/admissionregistration/v1/validating_webhook_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for ValidatingWebhookConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ValidatingWebhookConfiguration {

--- a/src/v1_17/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
+++ b/src/v1_17/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for MutatingWebhookConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for MutatingWebhookConfiguration {

--- a/src/v1_17/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
+++ b/src/v1_17/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for ValidatingWebhookConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ValidatingWebhookConfiguration {

--- a/src/v1_17/api/apps/v1/controller_revision.rs
+++ b/src/v1_17/api/apps/v1/controller_revision.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ControllerRevision {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ControllerRevision {

--- a/src/v1_17/api/apps/v1/daemon_set.rs
+++ b/src/v1_17/api/apps/v1/daemon_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for DaemonSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for DaemonSet {

--- a/src/v1_17/api/apps/v1/deployment.rs
+++ b/src/v1_17/api/apps/v1/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_17/api/apps/v1/replica_set.rs
+++ b/src/v1_17/api/apps/v1/replica_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicaSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicaSet {

--- a/src/v1_17/api/apps/v1/stateful_set.rs
+++ b/src/v1_17/api/apps/v1/stateful_set.rs
@@ -699,6 +699,15 @@ impl crate::Metadata for StatefulSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StatefulSet {

--- a/src/v1_17/api/apps/v1beta1/controller_revision.rs
+++ b/src/v1_17/api/apps/v1beta1/controller_revision.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ControllerRevision {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ControllerRevision {

--- a/src/v1_17/api/apps/v1beta1/deployment.rs
+++ b/src/v1_17/api/apps/v1beta1/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_17/api/apps/v1beta1/scale.rs
+++ b/src/v1_17/api/apps/v1beta1/scale.rs
@@ -414,6 +414,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_17/api/apps/v1beta1/stateful_set.rs
+++ b/src/v1_17/api/apps/v1beta1/stateful_set.rs
@@ -699,6 +699,15 @@ impl crate::Metadata for StatefulSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StatefulSet {

--- a/src/v1_17/api/apps/v1beta2/controller_revision.rs
+++ b/src/v1_17/api/apps/v1beta2/controller_revision.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ControllerRevision {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ControllerRevision {

--- a/src/v1_17/api/apps/v1beta2/daemon_set.rs
+++ b/src/v1_17/api/apps/v1beta2/daemon_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for DaemonSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for DaemonSet {

--- a/src/v1_17/api/apps/v1beta2/deployment.rs
+++ b/src/v1_17/api/apps/v1beta2/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_17/api/apps/v1beta2/replica_set.rs
+++ b/src/v1_17/api/apps/v1beta2/replica_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicaSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicaSet {

--- a/src/v1_17/api/apps/v1beta2/scale.rs
+++ b/src/v1_17/api/apps/v1beta2/scale.rs
@@ -606,6 +606,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_17/api/apps/v1beta2/stateful_set.rs
+++ b/src/v1_17/api/apps/v1beta2/stateful_set.rs
@@ -699,6 +699,15 @@ impl crate::Metadata for StatefulSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StatefulSet {

--- a/src/v1_17/api/auditregistration/v1alpha1/audit_sink.rs
+++ b/src/v1_17/api/auditregistration/v1alpha1/audit_sink.rs
@@ -385,6 +385,15 @@ impl crate::Metadata for AuditSink {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for AuditSink {

--- a/src/v1_17/api/authentication/v1/token_request.rs
+++ b/src/v1_17/api/authentication/v1/token_request.rs
@@ -74,6 +74,15 @@ impl crate::Metadata for TokenRequest {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for TokenRequest {

--- a/src/v1_17/api/authentication/v1/token_review.rs
+++ b/src/v1_17/api/authentication/v1/token_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for TokenReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for TokenReview {

--- a/src/v1_17/api/authentication/v1beta1/token_review.rs
+++ b/src/v1_17/api/authentication/v1beta1/token_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for TokenReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for TokenReview {

--- a/src/v1_17/api/authorization/v1/local_subject_access_review.rs
+++ b/src/v1_17/api/authorization/v1/local_subject_access_review.rs
@@ -70,6 +70,15 @@ impl crate::Metadata for LocalSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LocalSubjectAccessReview {

--- a/src/v1_17/api/authorization/v1/self_subject_access_review.rs
+++ b/src/v1_17/api/authorization/v1/self_subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectAccessReview {

--- a/src/v1_17/api/authorization/v1/self_subject_rules_review.rs
+++ b/src/v1_17/api/authorization/v1/self_subject_rules_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectRulesReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectRulesReview {

--- a/src/v1_17/api/authorization/v1/subject_access_review.rs
+++ b/src/v1_17/api/authorization/v1/subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SubjectAccessReview {

--- a/src/v1_17/api/authorization/v1beta1/local_subject_access_review.rs
+++ b/src/v1_17/api/authorization/v1beta1/local_subject_access_review.rs
@@ -70,6 +70,15 @@ impl crate::Metadata for LocalSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LocalSubjectAccessReview {

--- a/src/v1_17/api/authorization/v1beta1/self_subject_access_review.rs
+++ b/src/v1_17/api/authorization/v1beta1/self_subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectAccessReview {

--- a/src/v1_17/api/authorization/v1beta1/self_subject_rules_review.rs
+++ b/src/v1_17/api/authorization/v1beta1/self_subject_rules_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectRulesReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectRulesReview {

--- a/src/v1_17/api/authorization/v1beta1/subject_access_review.rs
+++ b/src/v1_17/api/authorization/v1beta1/subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SubjectAccessReview {

--- a/src/v1_17/api/autoscaling/v1/horizontal_pod_autoscaler.rs
+++ b/src/v1_17/api/autoscaling/v1/horizontal_pod_autoscaler.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for HorizontalPodAutoscaler {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for HorizontalPodAutoscaler {

--- a/src/v1_17/api/autoscaling/v1/scale.rs
+++ b/src/v1_17/api/autoscaling/v1/scale.rs
@@ -798,6 +798,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_17/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
+++ b/src/v1_17/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for HorizontalPodAutoscaler {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for HorizontalPodAutoscaler {

--- a/src/v1_17/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
+++ b/src/v1_17/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for HorizontalPodAutoscaler {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for HorizontalPodAutoscaler {

--- a/src/v1_17/api/batch/v1/job.rs
+++ b/src/v1_17/api/batch/v1/job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Job {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Job {

--- a/src/v1_17/api/batch/v1beta1/cron_job.rs
+++ b/src/v1_17/api/batch/v1beta1/cron_job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for CronJob {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CronJob {

--- a/src/v1_17/api/batch/v2alpha1/cron_job.rs
+++ b/src/v1_17/api/batch/v2alpha1/cron_job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for CronJob {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CronJob {

--- a/src/v1_17/api/certificates/v1beta1/certificate_signing_request.rs
+++ b/src/v1_17/api/certificates/v1beta1/certificate_signing_request.rs
@@ -603,6 +603,15 @@ impl crate::Metadata for CertificateSigningRequest {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CertificateSigningRequest {

--- a/src/v1_17/api/coordination/v1/lease.rs
+++ b/src/v1_17/api/coordination/v1/lease.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for Lease {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Lease {

--- a/src/v1_17/api/coordination/v1beta1/lease.rs
+++ b/src/v1_17/api/coordination/v1beta1/lease.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for Lease {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Lease {

--- a/src/v1_17/api/core/v1/binding.rs
+++ b/src/v1_17/api/core/v1/binding.rs
@@ -115,6 +115,15 @@ impl crate::Metadata for Binding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Binding {

--- a/src/v1_17/api/core/v1/component_status.rs
+++ b/src/v1_17/api/core/v1/component_status.rs
@@ -183,6 +183,15 @@ impl crate::Metadata for ComponentStatus {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ComponentStatus {

--- a/src/v1_17/api/core/v1/config_map.rs
+++ b/src/v1_17/api/core/v1/config_map.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ConfigMap {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ConfigMap {

--- a/src/v1_17/api/core/v1/endpoints.rs
+++ b/src/v1_17/api/core/v1/endpoints.rs
@@ -513,6 +513,15 @@ impl crate::Metadata for Endpoints {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Endpoints {

--- a/src/v1_17/api/core/v1/event.rs
+++ b/src/v1_17/api/core/v1/event.rs
@@ -541,6 +541,15 @@ impl crate::Metadata for Event {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         Some(&self.metadata)
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        Some(&mut self.metadata)
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=metadata;
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Event {

--- a/src/v1_17/api/core/v1/limit_range.rs
+++ b/src/v1_17/api/core/v1/limit_range.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for LimitRange {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LimitRange {

--- a/src/v1_17/api/core/v1/namespace.rs
+++ b/src/v1_17/api/core/v1/namespace.rs
@@ -568,6 +568,15 @@ impl crate::Metadata for Namespace {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Namespace {

--- a/src/v1_17/api/core/v1/node.rs
+++ b/src/v1_17/api/core/v1/node.rs
@@ -1043,6 +1043,15 @@ impl crate::Metadata for Node {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Node {

--- a/src/v1_17/api/core/v1/persistent_volume.rs
+++ b/src/v1_17/api/core/v1/persistent_volume.rs
@@ -563,6 +563,15 @@ impl crate::Metadata for PersistentVolume {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PersistentVolume {

--- a/src/v1_17/api/core/v1/persistent_volume_claim.rs
+++ b/src/v1_17/api/core/v1/persistent_volume_claim.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for PersistentVolumeClaim {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PersistentVolumeClaim {

--- a/src/v1_17/api/core/v1/pod.rs
+++ b/src/v1_17/api/core/v1/pod.rs
@@ -1803,6 +1803,15 @@ impl crate::Metadata for Pod {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Pod {

--- a/src/v1_17/api/core/v1/pod_template.rs
+++ b/src/v1_17/api/core/v1/pod_template.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for PodTemplate {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodTemplate {

--- a/src/v1_17/api/core/v1/replication_controller.rs
+++ b/src/v1_17/api/core/v1/replication_controller.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicationController {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicationController {

--- a/src/v1_17/api/core/v1/resource_quota.rs
+++ b/src/v1_17/api/core/v1/resource_quota.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ResourceQuota {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ResourceQuota {

--- a/src/v1_17/api/core/v1/secret.rs
+++ b/src/v1_17/api/core/v1/secret.rs
@@ -508,6 +508,15 @@ impl crate::Metadata for Secret {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Secret {

--- a/src/v1_17/api/core/v1/service.rs
+++ b/src/v1_17/api/core/v1/service.rs
@@ -1194,6 +1194,15 @@ impl crate::Metadata for Service {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Service {

--- a/src/v1_17/api/core/v1/service_account.rs
+++ b/src/v1_17/api/core/v1/service_account.rs
@@ -508,6 +508,15 @@ impl crate::Metadata for ServiceAccount {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ServiceAccount {

--- a/src/v1_17/api/discovery/v1beta1/endpoint_slice.rs
+++ b/src/v1_17/api/discovery/v1beta1/endpoint_slice.rs
@@ -508,6 +508,15 @@ impl crate::Metadata for EndpointSlice {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for EndpointSlice {

--- a/src/v1_17/api/events/v1beta1/event.rs
+++ b/src/v1_17/api/events/v1beta1/event.rs
@@ -540,6 +540,15 @@ impl crate::Metadata for Event {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Event {

--- a/src/v1_17/api/extensions/v1beta1/daemon_set.rs
+++ b/src/v1_17/api/extensions/v1beta1/daemon_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for DaemonSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for DaemonSet {

--- a/src/v1_17/api/extensions/v1beta1/deployment.rs
+++ b/src/v1_17/api/extensions/v1beta1/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_17/api/extensions/v1beta1/ingress.rs
+++ b/src/v1_17/api/extensions/v1beta1/ingress.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Ingress {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Ingress {

--- a/src/v1_17/api/extensions/v1beta1/network_policy.rs
+++ b/src/v1_17/api/extensions/v1beta1/network_policy.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for NetworkPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for NetworkPolicy {

--- a/src/v1_17/api/extensions/v1beta1/pod_security_policy.rs
+++ b/src/v1_17/api/extensions/v1beta1/pod_security_policy.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for PodSecurityPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodSecurityPolicy {

--- a/src/v1_17/api/extensions/v1beta1/replica_set.rs
+++ b/src/v1_17/api/extensions/v1beta1/replica_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicaSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicaSet {

--- a/src/v1_17/api/extensions/v1beta1/scale.rs
+++ b/src/v1_17/api/extensions/v1beta1/scale.rs
@@ -606,6 +606,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_17/api/flowcontrol/v1alpha1/flow_schema.rs
+++ b/src/v1_17/api/flowcontrol/v1alpha1/flow_schema.rs
@@ -563,6 +563,15 @@ impl crate::Metadata for FlowSchema {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for FlowSchema {

--- a/src/v1_17/api/flowcontrol/v1alpha1/priority_level_configuration.rs
+++ b/src/v1_17/api/flowcontrol/v1alpha1/priority_level_configuration.rs
@@ -563,6 +563,15 @@ impl crate::Metadata for PriorityLevelConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PriorityLevelConfiguration {

--- a/src/v1_17/api/networking/v1/network_policy.rs
+++ b/src/v1_17/api/networking/v1/network_policy.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for NetworkPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for NetworkPolicy {

--- a/src/v1_17/api/networking/v1beta1/ingress.rs
+++ b/src/v1_17/api/networking/v1beta1/ingress.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Ingress {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Ingress {

--- a/src/v1_17/api/node/v1alpha1/runtime_class.rs
+++ b/src/v1_17/api/node/v1alpha1/runtime_class.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for RuntimeClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RuntimeClass {

--- a/src/v1_17/api/node/v1beta1/runtime_class.rs
+++ b/src/v1_17/api/node/v1beta1/runtime_class.rs
@@ -392,6 +392,15 @@ impl crate::Metadata for RuntimeClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RuntimeClass {

--- a/src/v1_17/api/policy/v1beta1/eviction.rs
+++ b/src/v1_17/api/policy/v1beta1/eviction.rs
@@ -74,6 +74,15 @@ impl crate::Metadata for Eviction {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Eviction {

--- a/src/v1_17/api/policy/v1beta1/pod_disruption_budget.rs
+++ b/src/v1_17/api/policy/v1beta1/pod_disruption_budget.rs
@@ -696,6 +696,15 @@ impl crate::Metadata for PodDisruptionBudget {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodDisruptionBudget {

--- a/src/v1_17/api/policy/v1beta1/pod_security_policy.rs
+++ b/src/v1_17/api/policy/v1beta1/pod_security_policy.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for PodSecurityPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodSecurityPolicy {

--- a/src/v1_17/api/rbac/v1/cluster_role.rs
+++ b/src/v1_17/api/rbac/v1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_17/api/rbac/v1/cluster_role_binding.rs
+++ b/src/v1_17/api/rbac/v1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_17/api/rbac/v1/role.rs
+++ b/src/v1_17/api/rbac/v1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_17/api/rbac/v1/role_binding.rs
+++ b/src/v1_17/api/rbac/v1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_17/api/rbac/v1alpha1/cluster_role.rs
+++ b/src/v1_17/api/rbac/v1alpha1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_17/api/rbac/v1alpha1/cluster_role_binding.rs
+++ b/src/v1_17/api/rbac/v1alpha1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_17/api/rbac/v1alpha1/role.rs
+++ b/src/v1_17/api/rbac/v1alpha1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_17/api/rbac/v1alpha1/role_binding.rs
+++ b/src/v1_17/api/rbac/v1alpha1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_17/api/rbac/v1beta1/cluster_role.rs
+++ b/src/v1_17/api/rbac/v1beta1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_17/api/rbac/v1beta1/cluster_role_binding.rs
+++ b/src/v1_17/api/rbac/v1beta1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_17/api/rbac/v1beta1/role.rs
+++ b/src/v1_17/api/rbac/v1beta1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_17/api/rbac/v1beta1/role_binding.rs
+++ b/src/v1_17/api/rbac/v1beta1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_17/api/scheduling/v1/priority_class.rs
+++ b/src/v1_17/api/scheduling/v1/priority_class.rs
@@ -395,6 +395,15 @@ impl crate::Metadata for PriorityClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PriorityClass {

--- a/src/v1_17/api/scheduling/v1alpha1/priority_class.rs
+++ b/src/v1_17/api/scheduling/v1alpha1/priority_class.rs
@@ -395,6 +395,15 @@ impl crate::Metadata for PriorityClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PriorityClass {

--- a/src/v1_17/api/scheduling/v1beta1/priority_class.rs
+++ b/src/v1_17/api/scheduling/v1beta1/priority_class.rs
@@ -395,6 +395,15 @@ impl crate::Metadata for PriorityClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PriorityClass {

--- a/src/v1_17/api/settings/v1alpha1/pod_preset.rs
+++ b/src/v1_17/api/settings/v1alpha1/pod_preset.rs
@@ -500,6 +500,15 @@ impl crate::Metadata for PodPreset {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodPreset {

--- a/src/v1_17/api/storage/v1/csi_node.rs
+++ b/src/v1_17/api/storage/v1/csi_node.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for CSINode {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CSINode {

--- a/src/v1_17/api/storage/v1/storage_class.rs
+++ b/src/v1_17/api/storage/v1/storage_class.rs
@@ -406,6 +406,15 @@ impl crate::Metadata for StorageClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StorageClass {

--- a/src/v1_17/api/storage/v1/volume_attachment.rs
+++ b/src/v1_17/api/storage/v1/volume_attachment.rs
@@ -565,6 +565,15 @@ impl crate::Metadata for VolumeAttachment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for VolumeAttachment {

--- a/src/v1_17/api/storage/v1alpha1/volume_attachment.rs
+++ b/src/v1_17/api/storage/v1alpha1/volume_attachment.rs
@@ -391,6 +391,15 @@ impl crate::Metadata for VolumeAttachment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for VolumeAttachment {

--- a/src/v1_17/api/storage/v1beta1/csi_driver.rs
+++ b/src/v1_17/api/storage/v1beta1/csi_driver.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for CSIDriver {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CSIDriver {

--- a/src/v1_17/api/storage/v1beta1/csi_node.rs
+++ b/src/v1_17/api/storage/v1beta1/csi_node.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for CSINode {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CSINode {

--- a/src/v1_17/api/storage/v1beta1/storage_class.rs
+++ b/src/v1_17/api/storage/v1beta1/storage_class.rs
@@ -406,6 +406,15 @@ impl crate::Metadata for StorageClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StorageClass {

--- a/src/v1_17/api/storage/v1beta1/volume_attachment.rs
+++ b/src/v1_17/api/storage/v1beta1/volume_attachment.rs
@@ -391,6 +391,15 @@ impl crate::Metadata for VolumeAttachment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for VolumeAttachment {

--- a/src/v1_17/apiextensions_apiserver/pkg/apis/apiextensions/v1/custom_resource_definition.rs
+++ b/src/v1_17/apiextensions_apiserver/pkg/apis/apiextensions/v1/custom_resource_definition.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for CustomResourceDefinition {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CustomResourceDefinition {

--- a/src/v1_17/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
+++ b/src/v1_17/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for CustomResourceDefinition {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CustomResourceDefinition {

--- a/src/v1_17/apimachinery/pkg/apis/meta/v1/status.rs
+++ b/src/v1_17/apimachinery/pkg/apis/meta/v1/status.rs
@@ -35,6 +35,15 @@ impl crate::Metadata for Status {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Status {

--- a/src/v1_17/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
+++ b/src/v1_17/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for APIService {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for APIService {

--- a/src/v1_17/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
+++ b/src/v1_17/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for APIService {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for APIService {

--- a/src/v1_17/list.rs
+++ b/src/v1_17/list.rs
@@ -23,6 +23,15 @@ impl<T> crate::Metadata for List<T> where T: crate::ListableResource {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de, T> serde::Deserialize<'de> for List<T> where T: serde::Deserialize<'de> + crate::ListableResource {

--- a/src/v1_18/api/admissionregistration/v1/mutating_webhook_configuration.rs
+++ b/src/v1_18/api/admissionregistration/v1/mutating_webhook_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for MutatingWebhookConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for MutatingWebhookConfiguration {

--- a/src/v1_18/api/admissionregistration/v1/validating_webhook_configuration.rs
+++ b/src/v1_18/api/admissionregistration/v1/validating_webhook_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for ValidatingWebhookConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ValidatingWebhookConfiguration {

--- a/src/v1_18/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
+++ b/src/v1_18/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for MutatingWebhookConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for MutatingWebhookConfiguration {

--- a/src/v1_18/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
+++ b/src/v1_18/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for ValidatingWebhookConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ValidatingWebhookConfiguration {

--- a/src/v1_18/api/apps/v1/controller_revision.rs
+++ b/src/v1_18/api/apps/v1/controller_revision.rs
@@ -505,6 +505,15 @@ impl crate::Metadata for ControllerRevision {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ControllerRevision {

--- a/src/v1_18/api/apps/v1/daemon_set.rs
+++ b/src/v1_18/api/apps/v1/daemon_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for DaemonSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for DaemonSet {

--- a/src/v1_18/api/apps/v1/deployment.rs
+++ b/src/v1_18/api/apps/v1/deployment.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Deployment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Deployment {

--- a/src/v1_18/api/apps/v1/replica_set.rs
+++ b/src/v1_18/api/apps/v1/replica_set.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicaSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicaSet {

--- a/src/v1_18/api/apps/v1/stateful_set.rs
+++ b/src/v1_18/api/apps/v1/stateful_set.rs
@@ -699,6 +699,15 @@ impl crate::Metadata for StatefulSet {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StatefulSet {

--- a/src/v1_18/api/auditregistration/v1alpha1/audit_sink.rs
+++ b/src/v1_18/api/auditregistration/v1alpha1/audit_sink.rs
@@ -385,6 +385,15 @@ impl crate::Metadata for AuditSink {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for AuditSink {

--- a/src/v1_18/api/authentication/v1/token_request.rs
+++ b/src/v1_18/api/authentication/v1/token_request.rs
@@ -74,6 +74,15 @@ impl crate::Metadata for TokenRequest {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for TokenRequest {

--- a/src/v1_18/api/authentication/v1/token_review.rs
+++ b/src/v1_18/api/authentication/v1/token_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for TokenReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for TokenReview {

--- a/src/v1_18/api/authentication/v1beta1/token_review.rs
+++ b/src/v1_18/api/authentication/v1beta1/token_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for TokenReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for TokenReview {

--- a/src/v1_18/api/authorization/v1/local_subject_access_review.rs
+++ b/src/v1_18/api/authorization/v1/local_subject_access_review.rs
@@ -70,6 +70,15 @@ impl crate::Metadata for LocalSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LocalSubjectAccessReview {

--- a/src/v1_18/api/authorization/v1/self_subject_access_review.rs
+++ b/src/v1_18/api/authorization/v1/self_subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectAccessReview {

--- a/src/v1_18/api/authorization/v1/self_subject_rules_review.rs
+++ b/src/v1_18/api/authorization/v1/self_subject_rules_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectRulesReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectRulesReview {

--- a/src/v1_18/api/authorization/v1/subject_access_review.rs
+++ b/src/v1_18/api/authorization/v1/subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SubjectAccessReview {

--- a/src/v1_18/api/authorization/v1beta1/local_subject_access_review.rs
+++ b/src/v1_18/api/authorization/v1beta1/local_subject_access_review.rs
@@ -70,6 +70,15 @@ impl crate::Metadata for LocalSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LocalSubjectAccessReview {

--- a/src/v1_18/api/authorization/v1beta1/self_subject_access_review.rs
+++ b/src/v1_18/api/authorization/v1beta1/self_subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectAccessReview {

--- a/src/v1_18/api/authorization/v1beta1/self_subject_rules_review.rs
+++ b/src/v1_18/api/authorization/v1beta1/self_subject_rules_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SelfSubjectRulesReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SelfSubjectRulesReview {

--- a/src/v1_18/api/authorization/v1beta1/subject_access_review.rs
+++ b/src/v1_18/api/authorization/v1beta1/subject_access_review.rs
@@ -63,6 +63,15 @@ impl crate::Metadata for SubjectAccessReview {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for SubjectAccessReview {

--- a/src/v1_18/api/autoscaling/v1/horizontal_pod_autoscaler.rs
+++ b/src/v1_18/api/autoscaling/v1/horizontal_pod_autoscaler.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for HorizontalPodAutoscaler {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for HorizontalPodAutoscaler {

--- a/src/v1_18/api/autoscaling/v1/scale.rs
+++ b/src/v1_18/api/autoscaling/v1/scale.rs
@@ -798,6 +798,15 @@ impl crate::Metadata for Scale {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Scale {

--- a/src/v1_18/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
+++ b/src/v1_18/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for HorizontalPodAutoscaler {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for HorizontalPodAutoscaler {

--- a/src/v1_18/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
+++ b/src/v1_18/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for HorizontalPodAutoscaler {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for HorizontalPodAutoscaler {

--- a/src/v1_18/api/batch/v1/job.rs
+++ b/src/v1_18/api/batch/v1/job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Job {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Job {

--- a/src/v1_18/api/batch/v1beta1/cron_job.rs
+++ b/src/v1_18/api/batch/v1beta1/cron_job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for CronJob {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CronJob {

--- a/src/v1_18/api/batch/v2alpha1/cron_job.rs
+++ b/src/v1_18/api/batch/v2alpha1/cron_job.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for CronJob {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CronJob {

--- a/src/v1_18/api/certificates/v1beta1/certificate_signing_request.rs
+++ b/src/v1_18/api/certificates/v1beta1/certificate_signing_request.rs
@@ -603,6 +603,15 @@ impl crate::Metadata for CertificateSigningRequest {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CertificateSigningRequest {

--- a/src/v1_18/api/coordination/v1/lease.rs
+++ b/src/v1_18/api/coordination/v1/lease.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for Lease {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Lease {

--- a/src/v1_18/api/coordination/v1beta1/lease.rs
+++ b/src/v1_18/api/coordination/v1beta1/lease.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for Lease {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Lease {

--- a/src/v1_18/api/core/v1/binding.rs
+++ b/src/v1_18/api/core/v1/binding.rs
@@ -115,6 +115,15 @@ impl crate::Metadata for Binding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Binding {

--- a/src/v1_18/api/core/v1/component_status.rs
+++ b/src/v1_18/api/core/v1/component_status.rs
@@ -183,6 +183,15 @@ impl crate::Metadata for ComponentStatus {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ComponentStatus {

--- a/src/v1_18/api/core/v1/config_map.rs
+++ b/src/v1_18/api/core/v1/config_map.rs
@@ -508,6 +508,15 @@ impl crate::Metadata for ConfigMap {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ConfigMap {

--- a/src/v1_18/api/core/v1/endpoints.rs
+++ b/src/v1_18/api/core/v1/endpoints.rs
@@ -513,6 +513,15 @@ impl crate::Metadata for Endpoints {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Endpoints {

--- a/src/v1_18/api/core/v1/event.rs
+++ b/src/v1_18/api/core/v1/event.rs
@@ -541,6 +541,15 @@ impl crate::Metadata for Event {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         Some(&self.metadata)
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        Some(&mut self.metadata)
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=metadata;
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Event {

--- a/src/v1_18/api/core/v1/limit_range.rs
+++ b/src/v1_18/api/core/v1/limit_range.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for LimitRange {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for LimitRange {

--- a/src/v1_18/api/core/v1/namespace.rs
+++ b/src/v1_18/api/core/v1/namespace.rs
@@ -568,6 +568,15 @@ impl crate::Metadata for Namespace {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Namespace {

--- a/src/v1_18/api/core/v1/node.rs
+++ b/src/v1_18/api/core/v1/node.rs
@@ -1043,6 +1043,15 @@ impl crate::Metadata for Node {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Node {

--- a/src/v1_18/api/core/v1/persistent_volume.rs
+++ b/src/v1_18/api/core/v1/persistent_volume.rs
@@ -563,6 +563,15 @@ impl crate::Metadata for PersistentVolume {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PersistentVolume {

--- a/src/v1_18/api/core/v1/persistent_volume_claim.rs
+++ b/src/v1_18/api/core/v1/persistent_volume_claim.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for PersistentVolumeClaim {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PersistentVolumeClaim {

--- a/src/v1_18/api/core/v1/pod.rs
+++ b/src/v1_18/api/core/v1/pod.rs
@@ -1803,6 +1803,15 @@ impl crate::Metadata for Pod {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Pod {

--- a/src/v1_18/api/core/v1/pod_template.rs
+++ b/src/v1_18/api/core/v1/pod_template.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for PodTemplate {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodTemplate {

--- a/src/v1_18/api/core/v1/replication_controller.rs
+++ b/src/v1_18/api/core/v1/replication_controller.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ReplicationController {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ReplicationController {

--- a/src/v1_18/api/core/v1/resource_quota.rs
+++ b/src/v1_18/api/core/v1/resource_quota.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for ResourceQuota {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ResourceQuota {

--- a/src/v1_18/api/core/v1/secret.rs
+++ b/src/v1_18/api/core/v1/secret.rs
@@ -511,6 +511,15 @@ impl crate::Metadata for Secret {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Secret {

--- a/src/v1_18/api/core/v1/service.rs
+++ b/src/v1_18/api/core/v1/service.rs
@@ -1194,6 +1194,15 @@ impl crate::Metadata for Service {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Service {

--- a/src/v1_18/api/core/v1/service_account.rs
+++ b/src/v1_18/api/core/v1/service_account.rs
@@ -508,6 +508,15 @@ impl crate::Metadata for ServiceAccount {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ServiceAccount {

--- a/src/v1_18/api/discovery/v1beta1/endpoint_slice.rs
+++ b/src/v1_18/api/discovery/v1beta1/endpoint_slice.rs
@@ -508,6 +508,15 @@ impl crate::Metadata for EndpointSlice {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for EndpointSlice {

--- a/src/v1_18/api/events/v1beta1/event.rs
+++ b/src/v1_18/api/events/v1beta1/event.rs
@@ -540,6 +540,15 @@ impl crate::Metadata for Event {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Event {

--- a/src/v1_18/api/extensions/v1beta1/ingress.rs
+++ b/src/v1_18/api/extensions/v1beta1/ingress.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Ingress {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Ingress {

--- a/src/v1_18/api/flowcontrol/v1alpha1/flow_schema.rs
+++ b/src/v1_18/api/flowcontrol/v1alpha1/flow_schema.rs
@@ -563,6 +563,15 @@ impl crate::Metadata for FlowSchema {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for FlowSchema {

--- a/src/v1_18/api/flowcontrol/v1alpha1/priority_level_configuration.rs
+++ b/src/v1_18/api/flowcontrol/v1alpha1/priority_level_configuration.rs
@@ -563,6 +563,15 @@ impl crate::Metadata for PriorityLevelConfiguration {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PriorityLevelConfiguration {

--- a/src/v1_18/api/networking/v1/network_policy.rs
+++ b/src/v1_18/api/networking/v1/network_policy.rs
@@ -502,6 +502,15 @@ impl crate::Metadata for NetworkPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for NetworkPolicy {

--- a/src/v1_18/api/networking/v1beta1/ingress.rs
+++ b/src/v1_18/api/networking/v1beta1/ingress.rs
@@ -697,6 +697,15 @@ impl crate::Metadata for Ingress {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Ingress {

--- a/src/v1_18/api/networking/v1beta1/ingress_class.rs
+++ b/src/v1_18/api/networking/v1beta1/ingress_class.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for IngressClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for IngressClass {

--- a/src/v1_18/api/node/v1alpha1/runtime_class.rs
+++ b/src/v1_18/api/node/v1alpha1/runtime_class.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for RuntimeClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RuntimeClass {

--- a/src/v1_18/api/node/v1beta1/runtime_class.rs
+++ b/src/v1_18/api/node/v1beta1/runtime_class.rs
@@ -392,6 +392,15 @@ impl crate::Metadata for RuntimeClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RuntimeClass {

--- a/src/v1_18/api/policy/v1beta1/eviction.rs
+++ b/src/v1_18/api/policy/v1beta1/eviction.rs
@@ -74,6 +74,15 @@ impl crate::Metadata for Eviction {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Eviction {

--- a/src/v1_18/api/policy/v1beta1/pod_disruption_budget.rs
+++ b/src/v1_18/api/policy/v1beta1/pod_disruption_budget.rs
@@ -696,6 +696,15 @@ impl crate::Metadata for PodDisruptionBudget {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodDisruptionBudget {

--- a/src/v1_18/api/policy/v1beta1/pod_security_policy.rs
+++ b/src/v1_18/api/policy/v1beta1/pod_security_policy.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for PodSecurityPolicy {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodSecurityPolicy {

--- a/src/v1_18/api/rbac/v1/cluster_role.rs
+++ b/src/v1_18/api/rbac/v1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_18/api/rbac/v1/cluster_role_binding.rs
+++ b/src/v1_18/api/rbac/v1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_18/api/rbac/v1/role.rs
+++ b/src/v1_18/api/rbac/v1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_18/api/rbac/v1/role_binding.rs
+++ b/src/v1_18/api/rbac/v1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_18/api/rbac/v1alpha1/cluster_role.rs
+++ b/src/v1_18/api/rbac/v1alpha1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_18/api/rbac/v1alpha1/cluster_role_binding.rs
+++ b/src/v1_18/api/rbac/v1alpha1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_18/api/rbac/v1alpha1/role.rs
+++ b/src/v1_18/api/rbac/v1alpha1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_18/api/rbac/v1alpha1/role_binding.rs
+++ b/src/v1_18/api/rbac/v1alpha1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_18/api/rbac/v1beta1/cluster_role.rs
+++ b/src/v1_18/api/rbac/v1beta1/cluster_role.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRole {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRole {

--- a/src/v1_18/api/rbac/v1beta1/cluster_role_binding.rs
+++ b/src/v1_18/api/rbac/v1beta1/cluster_role_binding.rs
@@ -377,6 +377,15 @@ impl crate::Metadata for ClusterRoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for ClusterRoleBinding {

--- a/src/v1_18/api/rbac/v1beta1/role.rs
+++ b/src/v1_18/api/rbac/v1beta1/role.rs
@@ -490,6 +490,15 @@ impl crate::Metadata for Role {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Role {

--- a/src/v1_18/api/rbac/v1beta1/role_binding.rs
+++ b/src/v1_18/api/rbac/v1beta1/role_binding.rs
@@ -493,6 +493,15 @@ impl crate::Metadata for RoleBinding {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for RoleBinding {

--- a/src/v1_18/api/scheduling/v1/priority_class.rs
+++ b/src/v1_18/api/scheduling/v1/priority_class.rs
@@ -395,6 +395,15 @@ impl crate::Metadata for PriorityClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PriorityClass {

--- a/src/v1_18/api/scheduling/v1alpha1/priority_class.rs
+++ b/src/v1_18/api/scheduling/v1alpha1/priority_class.rs
@@ -395,6 +395,15 @@ impl crate::Metadata for PriorityClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PriorityClass {

--- a/src/v1_18/api/scheduling/v1beta1/priority_class.rs
+++ b/src/v1_18/api/scheduling/v1beta1/priority_class.rs
@@ -395,6 +395,15 @@ impl crate::Metadata for PriorityClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PriorityClass {

--- a/src/v1_18/api/settings/v1alpha1/pod_preset.rs
+++ b/src/v1_18/api/settings/v1alpha1/pod_preset.rs
@@ -500,6 +500,15 @@ impl crate::Metadata for PodPreset {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for PodPreset {

--- a/src/v1_18/api/storage/v1/csi_driver.rs
+++ b/src/v1_18/api/storage/v1/csi_driver.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for CSIDriver {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CSIDriver {

--- a/src/v1_18/api/storage/v1/csi_node.rs
+++ b/src/v1_18/api/storage/v1/csi_node.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for CSINode {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CSINode {

--- a/src/v1_18/api/storage/v1/storage_class.rs
+++ b/src/v1_18/api/storage/v1/storage_class.rs
@@ -406,6 +406,15 @@ impl crate::Metadata for StorageClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StorageClass {

--- a/src/v1_18/api/storage/v1/volume_attachment.rs
+++ b/src/v1_18/api/storage/v1/volume_attachment.rs
@@ -565,6 +565,15 @@ impl crate::Metadata for VolumeAttachment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for VolumeAttachment {

--- a/src/v1_18/api/storage/v1alpha1/volume_attachment.rs
+++ b/src/v1_18/api/storage/v1alpha1/volume_attachment.rs
@@ -391,6 +391,15 @@ impl crate::Metadata for VolumeAttachment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for VolumeAttachment {

--- a/src/v1_18/api/storage/v1beta1/csi_driver.rs
+++ b/src/v1_18/api/storage/v1beta1/csi_driver.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for CSIDriver {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CSIDriver {

--- a/src/v1_18/api/storage/v1beta1/csi_node.rs
+++ b/src/v1_18/api/storage/v1beta1/csi_node.rs
@@ -386,6 +386,15 @@ impl crate::Metadata for CSINode {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CSINode {

--- a/src/v1_18/api/storage/v1beta1/storage_class.rs
+++ b/src/v1_18/api/storage/v1beta1/storage_class.rs
@@ -406,6 +406,15 @@ impl crate::Metadata for StorageClass {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for StorageClass {

--- a/src/v1_18/api/storage/v1beta1/volume_attachment.rs
+++ b/src/v1_18/api/storage/v1beta1/volume_attachment.rs
@@ -391,6 +391,15 @@ impl crate::Metadata for VolumeAttachment {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for VolumeAttachment {

--- a/src/v1_18/apiextensions_apiserver/pkg/apis/apiextensions/v1/custom_resource_definition.rs
+++ b/src/v1_18/apiextensions_apiserver/pkg/apis/apiextensions/v1/custom_resource_definition.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for CustomResourceDefinition {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CustomResourceDefinition {

--- a/src/v1_18/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
+++ b/src/v1_18/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for CustomResourceDefinition {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for CustomResourceDefinition {

--- a/src/v1_18/apimachinery/pkg/apis/meta/v1/status.rs
+++ b/src/v1_18/apimachinery/pkg/apis/meta/v1/status.rs
@@ -35,6 +35,15 @@ impl crate::Metadata for Status {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for Status {

--- a/src/v1_18/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
+++ b/src/v1_18/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for APIService {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for APIService {

--- a/src/v1_18/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
+++ b/src/v1_18/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
@@ -562,6 +562,15 @@ impl crate::Metadata for APIService {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de> serde::Deserialize<'de> for APIService {

--- a/src/v1_18/list.rs
+++ b/src/v1_18/list.rs
@@ -23,6 +23,15 @@ impl<T> crate::Metadata for List<T> where T: crate::ListableResource {
     fn metadata(&self) -> Option<&<Self as crate::Metadata>::Ty> {
         self.metadata.as_ref()
     }
+
+    fn metadata_mut(&mut self) -> Option<&mut<Self as crate::Metadata>::Ty> {
+        self.metadata.as_mut()
+    }
+
+    fn set_metadata(&mut self, metadata: <Self as crate::Metadata>::Ty) {
+        self.metadata=Some(metadata);
+    }
+
 }
 
 impl<'de, T> serde::Deserialize<'de> for List<T> where T: serde::Deserialize<'de> + crate::ListableResource {


### PR DESCRIPTION
I had to create two new methods (but maybe there is a better way):

~~~rust
    /// Gets the mutable metadata of this resource value.
    fn metadata_mut(&mut self) -> Option<&mut<Self as Metadata>::Ty>;

    /// Sets the metadata of this resource value.
    fn set_metadata(&mut self, metadata: <Self as Metadata>::Ty);
~~~

The first allows to get an Option, holding a mutable reference to the metadata. However when using `Default::default()`, you get empty metadata and need a way to set it. I would have used `fn metadata_mut(&mut self) -> &mut Option<<Self as Metadata>::Ty>` instead, but in some cases the value is not backed by an Option, but rather by the actual value.

So I added a second `set_metedata` function, which allows to set the value. As in some cases the value may be backed by the actual value, I don't think a "clear" method is possible.