### PR TITLE
Update bytes to v1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ links = "k8s-openapi-0.10.0"
 
 [dependencies]
 base64 = "0.13"
-bytes = "0.5"
+bytes = "1"
 chrono = { version = "0.4.1", features = ["serde"] }
 http = { version = "0.2", optional = true }
 percent-encoding = { version = "2", optional = true }


### PR DESCRIPTION
@Arnavion Thanks for `k8s-openapi` :)

`kube` updated to `tokio` v1, and it'll be nice to avoid having two versions of `bytes`.

Changelogs:

- https://github.com/tokio-rs/bytes/releases/tag/v0.6.0
- https://github.com/tokio-rs/bytes/releases/tag/v1.0.0