### PR TITLE
Support custom spec sources

### DIFF
--- a/k8s-openapi-codegen/Cargo.toml
+++ b/k8s-openapi-codegen/Cargo.toml
@@ -14,3 +14,4 @@ log = "0.4"
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "default-tls", "json"] }
 serde = "1"
 serde_derive = "1"
+structopt = "0.3.21"

--- a/k8s-openapi-codegen/README.md
+++ b/k8s-openapi-codegen/README.md
@@ -10,3 +10,6 @@ cargo run
 ```
 
 Bindings will now be generated in the `../` directory.
+
+Generator accepts command-line arguments for advanced usage scenarios, run
+`cargo run -- --help` for more details.

--- a/k8s-openapi-codegen/src/supported_version.rs
+++ b/k8s-openapi-codegen/src/supported_version.rs
@@ -26,6 +26,21 @@ pub(crate) enum SupportedVersion {
 }
 
 impl SupportedVersion {
+    pub(crate) fn name(self) -> &'static str {
+		match self {
+			SupportedVersion::V1_11 => "v1.11",
+			SupportedVersion::V1_12 => "v1.12",
+			SupportedVersion::V1_13 => "v1.13",
+			SupportedVersion::V1_14 => "v1.14",
+			SupportedVersion::V1_15 => "v1.15",
+			SupportedVersion::V1_16 => "v1.16",
+			SupportedVersion::V1_17 => "v1.17",
+			SupportedVersion::V1_18 => "v1.18",
+			SupportedVersion::V1_19 => "v1.19",
+			SupportedVersion::V1_20 => "v1.20",	
+		}
+	}
+
 	pub(crate) fn mod_root(self) -> &'static str {
 		match self {
 			SupportedVersion::V1_11 => "v1_11",


### PR DESCRIPTION
Usage example:
```bash
kubectl proxy &
cd k8s-openapi-codegen
VERSIONS=v1.20=http://127.0.0.1:8001/openapi/v2 cargo run
```
This change is not useful on its own, but it eventually it should allow support non-builtin API groups, such as `metrics.k8s.io`.

I have not written any documentation yet. What is the best location for docs?

To summarize, using the `VERSIONS` environment variable user can:
1) Request that only a subset of kubernetes versions should be handled
2) For each version they can provide custom specification URL
E.g.:
`VERSIONS=v.19,v1.20=http://foo.bar/spec.json`
Here codegen will generate v1.19 (using spec from k/k github repository) and v1.20 (using spec from `http://foo.bar/spec.json`)