### PR TITLE
Improve listable ergonomics (#72)

### DIFF
--- a/k8s-openapi-codegen-common/src/lib.rs
+++ b/k8s-openapi-codegen-common/src/lib.rs
@@ -261,7 +261,7 @@ pub fn run(
 
 					let mut field_type_name = String::new();
 
-										let ser_skip = get_ser_skip(&schema.kind);
+					let ser_skip = get_ser_skip(&schema.kind);
 
 					if !required && ser_skip.is_none() {
 						write!(field_type_name, "Option<")?;
@@ -303,7 +303,7 @@ pub fn run(
 					result.push(templates::Property {
 						name,
 						comment: schema.description.as_deref(),
-												ser_skip,
+						ser_skip,
 						field_name,
 						field_type_name,
 						required: *required,
@@ -562,7 +562,7 @@ pub fn run(
 				templates::Property {
 					name: "items",
 					comment: Some("List of objects."),
-										ser_skip: Some("Vec::is_empty"), // probably not correct?
+					ser_skip: Some("Vec::is_empty"), // probably not correct?
 					field_name: "items".into(),
 					field_type_name: "Vec<T>".to_owned(),
 					required: true,
@@ -572,7 +572,7 @@ pub fn run(
 				templates::Property {
 					name: "metadata",
 					comment: Some("Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"),
-										ser_skip: None,
+					ser_skip: None,
 					field_name: "metadata".into(),
 					field_type_name: (&*metadata_rust_type).to_owned(),
 					required: true,
@@ -706,7 +706,7 @@ pub fn run(
 					result.push(templates::Property {
 						name,
 						comment: schema.description.as_deref(),
-												ser_skip: None, // need fix?
+						ser_skip: None, // need fix?
 						field_name,
 						field_type_name,
 						required: false,

--- a/k8s-openapi-codegen-common/src/lib.rs
+++ b/k8s-openapi-codegen-common/src/lib.rs
@@ -261,7 +261,7 @@ pub fn run(
 
 					let mut field_type_name = String::new();
 
-                    let ser_skip = get_ser_skip(&schema.kind);
+										let ser_skip = get_ser_skip(&schema.kind);
 
 					if !required && ser_skip.is_none() {
 						write!(field_type_name, "Option<")?;
@@ -303,7 +303,7 @@ pub fn run(
 					result.push(templates::Property {
 						name,
 						comment: schema.description.as_deref(),
-                        ser_skip,
+												ser_skip,
 						field_name,
 						field_type_name,
 						required: *required,
@@ -562,7 +562,7 @@ pub fn run(
 				templates::Property {
 					name: "items",
 					comment: Some("List of objects."),
-                    ser_skip: Some("Vec::is_empty"), // probably not correct?
+										ser_skip: Some("Vec::is_empty"), // probably not correct?
 					field_name: "items".into(),
 					field_type_name: "Vec<T>".to_owned(),
 					required: true,
@@ -572,7 +572,7 @@ pub fn run(
 				templates::Property {
 					name: "metadata",
 					comment: Some("Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"),
-                    ser_skip: None,
+										ser_skip: None,
 					field_name: "metadata".into(),
 					field_type_name: (&*metadata_rust_type).to_owned(),
 					required: true,
@@ -706,7 +706,7 @@ pub fn run(
 					result.push(templates::Property {
 						name,
 						comment: schema.description.as_deref(),
-                        ser_skip: None, // need fix?
+												ser_skip: None, // need fix?
 						field_name,
 						field_type_name,
 						required: false,
@@ -1401,11 +1401,11 @@ fn get_rust_type(
 }
 
 fn get_ser_skip(schema_kind: &swagger20::SchemaKind) -> Option<&'static str> {
-    match schema_kind {
-        swagger20::SchemaKind::Ty(swagger20::Type::Array { .. }) => Some("Vec::is_empty"),
-        swagger20::SchemaKind::Ty(swagger20::Type::Object { .. }) => Some("BTreeMap::is_empty"),
-        _ => None,
-    }
+	match schema_kind {
+		swagger20::SchemaKind::Ty(swagger20::Type::Array { .. }) => Some("Vec::is_empty"),
+		swagger20::SchemaKind::Ty(swagger20::Type::Object { .. }) => Some("std::collections::BTreeMap::is_empty"),
+			_ => None,
+	}
 }
 
 /// Each invocation of this function generates a single API operation function specified by the `operation` parameter.
@@ -1495,7 +1495,7 @@ pub fn write_operation(
 					path == "io.k8s.ListOptional" ||
 					path == "io.k8s.PatchOptional" ||
 					path == "io.k8s.ReplaceOptional" ||
-					path == "io.k8s.WatchOptional"
+					path == "io.k8s.WatchOptional" 
 				}
 				else {
 					false

--- a/k8s-openapi-codegen-common/src/templates/impl_deserialize.rs
+++ b/k8s-openapi-codegen-common/src/templates/impl_deserialize.rs
@@ -80,11 +80,11 @@ pub(crate) fn generate(
 			writeln!(str_to_field_match_arms, r#"                            {:?} => Field::Key_{},"#, name, field_name)?;
 
 			if *required {
-                if ser_skip.is_some() {
-                    writeln!(field_value_defs, r#"                let mut value_{}: {} = Default::default;"#, field_name, field_type_name)?;
-                } else {
-				    writeln!(field_value_defs, r#"                let mut value_{}: Option<{}> = None;"#, field_name, field_type_name)?;
-                }
+				if ser_skip.is_some() {
+					writeln!(field_value_defs, r#"                let mut value_{}: {} = Default::default();"#, field_name, field_type_name)?;
+				} else {
+					writeln!(field_value_defs, r#"                let mut value_{}: Option<{}> = None;"#, field_name, field_type_name)?;
+				}
 
 				writeln!(field_value_match_arms,
 					r#"                        Field::Key_{} => value_{} = Some({}serde::de::MapAccess::next_value(&mut map)?),"#,
@@ -93,11 +93,11 @@ pub(crate) fn generate(
 				writeln!(field_value_assignment, "                    {}: value_{}.ok_or_else(|| {}serde::de::Error::missing_field({:?}))?,", field_name, field_name, local, name)?;
 			}
 			else {
-                if ser_skip.is_some() {
-                    writeln!(field_value_defs, r#"                let mut value_{}: {} = Default::default();"#, field_name, field_type_name)?;
-                } else {
-				    writeln!(field_value_defs, r#"                let mut value_{}: {} = None;"#, field_name, field_type_name)?;
-                }
+				if ser_skip.is_some() {
+					writeln!(field_value_defs, r#"                let mut value_{}: {} = Default::default();"#, field_name, field_type_name)?;
+				} else {
+					writeln!(field_value_defs, r#"                let mut value_{}: {} = None;"#, field_name, field_type_name)?;
+				}
 
 				writeln!(field_value_match_arms, r#"                        Field::Key_{} => value_{} = {}serde::de::MapAccess::next_value(&mut map)?,"#, field_name, field_name, local)?;
 

--- a/k8s-openapi-codegen-common/src/templates/mod.rs
+++ b/k8s-openapi-codegen-common/src/templates/mod.rs
@@ -68,7 +68,7 @@ pub(crate) struct Generics<'a> {
 pub(crate) struct Property<'a> {
 	pub(crate) name: &'a str,
 	pub(crate) comment: Option<&'a str>,
-    pub(crate) ser_skip: Option<&'a str>,
+	pub(crate) ser_skip: Option<&'a str>,
 	pub(crate) field_name: std::borrow::Cow<'static, str>,
 	pub(crate) field_type_name: String,
 	pub(crate) required: bool,

--- a/k8s-openapi-codegen-common/src/templates/mod.rs
+++ b/k8s-openapi-codegen-common/src/templates/mod.rs
@@ -68,6 +68,7 @@ pub(crate) struct Generics<'a> {
 pub(crate) struct Property<'a> {
 	pub(crate) name: &'a str,
 	pub(crate) comment: Option<&'a str>,
+    pub(crate) ser_skip: Option<&'a str>,
 	pub(crate) field_name: std::borrow::Cow<'static, str>,
 	pub(crate) field_type_name: String,
 	pub(crate) required: bool,

--- a/k8s-openapi-codegen-common/src/templates/struct.rs
+++ b/k8s-openapi-codegen-common/src/templates/struct.rs
@@ -10,7 +10,7 @@ pub(crate) fn generate(
 
 	let fields: String = {
 		fields.iter()
-		.try_fold(String::new(), |mut fields, super::Property { comment, ser_skip, field_name, field_type_name, .. }| -> Result<_, std::fmt::Error> {
+		.try_fold(String::new(), |mut fields, super::Property { comment, field_name, field_type_name, .. }| -> Result<_, std::fmt::Error> {
 			use std::fmt::Write;
 
 			if !fields.is_empty() {
@@ -22,14 +22,6 @@ pub(crate) fn generate(
 					writeln!(&mut fields, "    ///{}", line)?;
 				}
 			}
-
-            if let Some(ss) = ser_skip {
-                writeln!(
-                    &mut fields,
-                    "    #[serde(default, skip_serializing_if = \"{}\")]",
-                    ss,
-                )?;
-            }
 
 			writeln!(&mut fields,
 				"    {vis}{field_name}: {field_type_name},",

--- a/k8s-openapi-codegen-common/src/templates/struct.rs
+++ b/k8s-openapi-codegen-common/src/templates/struct.rs
@@ -10,7 +10,7 @@ pub(crate) fn generate(
 
 	let fields: String = {
 		fields.iter()
-		.try_fold(String::new(), |mut fields, super::Property { comment, field_name, field_type_name, .. }| -> Result<_, std::fmt::Error> {
+		.try_fold(String::new(), |mut fields, super::Property { comment, ser_skip, field_name, field_type_name, .. }| -> Result<_, std::fmt::Error> {
 			use std::fmt::Write;
 
 			if !fields.is_empty() {
@@ -22,6 +22,14 @@ pub(crate) fn generate(
 					writeln!(&mut fields, "    ///{}", line)?;
 				}
 			}
+
+            if let Some(ss) = ser_skip {
+                writeln!(
+                    &mut fields,
+                    "    #[serde(default, skip_serializing_if = \"{}\")]",
+                    ss,
+                )?;
+            }
 
 			writeln!(&mut fields,
 				"    {vis}{field_name}: {field_type_name},",


### PR DESCRIPTION
This currently will change `Vec` and `BTreeMap` types like this:

![image](https://user-images.githubusercontent.com/222272/118370834-1745b480-b599-11eb-81be-3b149824141a.png)

I'm pretty sure there're some rough edges though:

- How this should work for "required" array/object, e.g. `containers` of `PodSpec`
- Whether I missed some codegen path (I guess CI would catch those)
- Whether this should be behind a "feature" gate
- And "minor" stuff like naming

Also, can you add a `rustfmt.toml` that codifies the formatter style you use for this project? Even with auto format disabled it seems I still missed that existing code uses tabs rather than whitespaces and so on. It would really help contributors if the formatter just handles these.