### PR TITLE
Add `PLURAL_NAME` and `Scope` to `Resource`

### DIFF
--- a/k8s-openapi-codegen-common/src/templates/impl_resource.rs
+++ b/k8s-openapi-codegen-common/src/templates/impl_resource.rs
@@ -11,6 +11,13 @@ pub(crate) fn generate(
 	let type_generics_type = generics.type_part.map(|part| format!("<{}>", part)).unwrap_or_default();
 	let type_generics_where = generics.where_part.map(|part| format!(" where {}", part)).unwrap_or_default();
 
+	let (namespaced, scope_type) = match resource_metadata.namespaced {
+		"true" => ("true".to_owned(), format!("{}NamespaceScopedResource", local)),
+		"false" =>  ("false".to_owned(), format!("{}ClusterScopedResource", local)),
+		"<T as crate::Resource>::NAMESPACED" => (format!("<T as {}Resource>::NAMESPACED", local), format!("<T as {}Resource>::Scope", local)),
+		_ => unreachable!(),
+	};
+
 	writeln!(
 		writer,
 		include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/templates/impl_resource.rs")),
@@ -22,7 +29,10 @@ pub(crate) fn generate(
 		api_version = resource_metadata.api_version,
 		group = resource_metadata.group,
 		kind = resource_metadata.kind,
+		resource_name = resource_metadata.name,
 		version = resource_metadata.version,
+		namespaced = namespaced,
+		scope_type = scope_type,
 	)?;
 
 	Ok(())

--- a/k8s-openapi-codegen-common/src/templates/mod.rs
+++ b/k8s-openapi-codegen-common/src/templates/mod.rs
@@ -86,9 +86,11 @@ pub(crate) struct ResourceMetadata<'a> {
 	pub(crate) api_version: &'a str,
 	pub(crate) group: &'a str,
 	pub(crate) kind: &'a str,
+	pub(crate) name: &'a str,
 	pub(crate) version: &'a str,
 	pub(crate) list_kind: Option<&'a str>,
 	pub(crate) metadata_ty: Option<&'a str>,
+	pub(crate) namespaced: &'a str,
 }
 
 #[derive(Clone, Copy)]

--- a/k8s-openapi-codegen-common/templates/impl_resource.rs
+++ b/k8s-openapi-codegen-common/templates/impl_resource.rs
@@ -3,5 +3,8 @@ impl{type_generics_impl} {local}Resource for {type_name}{type_generics_type}{typ
     const API_VERSION: &'static str = {api_version};
     const GROUP: &'static str = {group};
     const KIND: &'static str = {kind};
+    const PLURAL_NAME: &'static str = "{resource_name}";
     const VERSION: &'static str = {version};
+    const NAMESPACED: bool = {namespaced};
+    type Scope = {scope_type};
 }}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -501,6 +501,19 @@ impl serde::Serialize for ByteString {
     }
 }
 
+/// Describes resource scope.
+pub trait ResourceScope {}
+
+pub struct ClusterScopedResource;
+impl ResourceScope for ClusterScopedResource {}
+
+pub struct NamespaceScopedResource;
+impl ResourceScope for NamespaceScopedResource {}
+
+// Neither cluster nor namespace scoped.
+// pub struct NotScopedResource;
+// impl ResourceScope for NotScopedResource {}
+
 /// A trait applied to all Kubernetes resources.
 pub trait Resource {
     /// The API version of the resource. This is a composite of [`Resource::GROUP`] and [`Resource::VERSION`] (eg `"apiextensions.k8s.io/v1beta1"`)
@@ -517,8 +530,20 @@ pub trait Resource {
     /// This is the string used in the `kind` field of the resource's serialized form.
     const KIND: &'static str;
 
+    /// The plural name of the resource.
+    /// It can be used to construct URLs.
+    const PLURAL_NAME: &'static str;
+
     /// The version of the resource.
     const VERSION: &'static str;
+
+    /// If true, this resource is namespaced
+    const NAMESPACED: bool;
+
+    /// Type that represents scope of the resource.
+    /// If `NAMESPACED` is true, this is `NamespaceScopedResource`.
+    /// Otherwise, this is `ClusterScopedResource`.
+    type Scope: ResourceScope;
 }
 
 /// A trait applied to all Kubernetes resources that can be part of a corresponding list.

--- a/src/v1_11/api/admissionregistration/v1alpha1/initializer_configuration.rs
+++ b/src/v1_11/api/admissionregistration/v1alpha1/initializer_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for InitializerConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1alpha1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "InitializerConfiguration";
+    const PLURAL_NAME: &'static str = "initializerconfigurations";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for InitializerConfiguration {

--- a/src/v1_11/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
+++ b/src/v1_11/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for MutatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "MutatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "mutatingwebhookconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for MutatingWebhookConfiguration {

--- a/src/v1_11/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
+++ b/src/v1_11/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for ValidatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "ValidatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "validatingwebhookconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ValidatingWebhookConfiguration {

--- a/src/v1_11/api/apps/v1/controller_revision.rs
+++ b/src/v1_11/api/apps/v1/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_11/api/apps/v1/daemon_set.rs
+++ b/src/v1_11/api/apps/v1/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_11/api/apps/v1/deployment.rs
+++ b/src/v1_11/api/apps/v1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_11/api/apps/v1/replica_set.rs
+++ b/src/v1_11/api/apps/v1/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_11/api/apps/v1/stateful_set.rs
+++ b/src/v1_11/api/apps/v1/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_11/api/apps/v1beta1/controller_revision.rs
+++ b/src/v1_11/api/apps/v1beta1/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_11/api/apps/v1beta1/deployment.rs
+++ b/src/v1_11/api/apps/v1beta1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_11/api/apps/v1beta1/deployment_rollback.rs
+++ b/src/v1_11/api/apps/v1beta1/deployment_rollback.rs
@@ -124,7 +124,10 @@ impl crate::Resource for DeploymentRollback {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DeploymentRollback";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for DeploymentRollback {

--- a/src/v1_11/api/apps/v1beta1/scale.rs
+++ b/src/v1_11/api/apps/v1beta1/scale.rs
@@ -405,7 +405,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_11/api/apps/v1beta1/stateful_set.rs
+++ b/src/v1_11/api/apps/v1beta1/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_11/api/apps/v1beta2/controller_revision.rs
+++ b/src/v1_11/api/apps/v1beta2/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_11/api/apps/v1beta2/daemon_set.rs
+++ b/src/v1_11/api/apps/v1beta2/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_11/api/apps/v1beta2/deployment.rs
+++ b/src/v1_11/api/apps/v1beta2/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_11/api/apps/v1beta2/replica_set.rs
+++ b/src/v1_11/api/apps/v1beta2/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_11/api/apps/v1beta2/scale.rs
+++ b/src/v1_11/api/apps/v1beta2/scale.rs
@@ -597,7 +597,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_11/api/apps/v1beta2/stateful_set.rs
+++ b/src/v1_11/api/apps/v1beta2/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_11/api/authentication/v1/token_review.rs
+++ b/src/v1_11/api/authentication/v1/token_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for TokenReview {
     const API_VERSION: &'static str = "authentication.k8s.io/v1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenReview";
+    const PLURAL_NAME: &'static str = "tokenreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenReview {

--- a/src/v1_11/api/authentication/v1beta1/token_review.rs
+++ b/src/v1_11/api/authentication/v1beta1/token_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for TokenReview {
     const API_VERSION: &'static str = "authentication.k8s.io/v1beta1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenReview";
+    const PLURAL_NAME: &'static str = "tokenreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenReview {

--- a/src/v1_11/api/authorization/v1/local_subject_access_review.rs
+++ b/src/v1_11/api/authorization/v1/local_subject_access_review.rs
@@ -61,7 +61,10 @@ impl crate::Resource for LocalSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "LocalSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "localsubjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for LocalSubjectAccessReview {

--- a/src/v1_11/api/authorization/v1/self_subject_access_review.rs
+++ b/src/v1_11/api/authorization/v1/self_subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "selfsubjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectAccessReview {

--- a/src/v1_11/api/authorization/v1/self_subject_rules_review.rs
+++ b/src/v1_11/api/authorization/v1/self_subject_rules_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectRulesReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectRulesReview";
+    const PLURAL_NAME: &'static str = "selfsubjectrulesreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectRulesReview {

--- a/src/v1_11/api/authorization/v1/subject_access_review.rs
+++ b/src/v1_11/api/authorization/v1/subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SubjectAccessReview";
+    const PLURAL_NAME: &'static str = "subjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SubjectAccessReview {

--- a/src/v1_11/api/authorization/v1beta1/local_subject_access_review.rs
+++ b/src/v1_11/api/authorization/v1beta1/local_subject_access_review.rs
@@ -61,7 +61,10 @@ impl crate::Resource for LocalSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "LocalSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "localsubjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for LocalSubjectAccessReview {

--- a/src/v1_11/api/authorization/v1beta1/self_subject_access_review.rs
+++ b/src/v1_11/api/authorization/v1beta1/self_subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "selfsubjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectAccessReview {

--- a/src/v1_11/api/authorization/v1beta1/self_subject_rules_review.rs
+++ b/src/v1_11/api/authorization/v1beta1/self_subject_rules_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectRulesReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectRulesReview";
+    const PLURAL_NAME: &'static str = "selfsubjectrulesreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectRulesReview {

--- a/src/v1_11/api/authorization/v1beta1/subject_access_review.rs
+++ b/src/v1_11/api/authorization/v1beta1/subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SubjectAccessReview";
+    const PLURAL_NAME: &'static str = "subjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SubjectAccessReview {

--- a/src/v1_11/api/autoscaling/v1/horizontal_pod_autoscaler.rs
+++ b/src/v1_11/api/autoscaling/v1/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_11/api/autoscaling/v1/scale.rs
+++ b/src/v1_11/api/autoscaling/v1/scale.rs
@@ -789,7 +789,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "autoscaling/v1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_11/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
+++ b/src/v1_11/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v2beta1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v2beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_11/api/batch/v1/job.rs
+++ b/src/v1_11/api/batch/v1/job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Job {
     const API_VERSION: &'static str = "batch/v1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "Job";
+    const PLURAL_NAME: &'static str = "jobs";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Job {

--- a/src/v1_11/api/batch/v1beta1/cron_job.rs
+++ b/src/v1_11/api/batch/v1beta1/cron_job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for CronJob {
     const API_VERSION: &'static str = "batch/v1beta1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "CronJob";
+    const PLURAL_NAME: &'static str = "cronjobs";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CronJob {

--- a/src/v1_11/api/batch/v2alpha1/cron_job.rs
+++ b/src/v1_11/api/batch/v2alpha1/cron_job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for CronJob {
     const API_VERSION: &'static str = "batch/v2alpha1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "CronJob";
+    const PLURAL_NAME: &'static str = "cronjobs";
     const VERSION: &'static str = "v2alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CronJob {

--- a/src/v1_11/api/certificates/v1beta1/certificate_signing_request.rs
+++ b/src/v1_11/api/certificates/v1beta1/certificate_signing_request.rs
@@ -590,7 +590,10 @@ impl crate::Resource for CertificateSigningRequest {
     const API_VERSION: &'static str = "certificates.k8s.io/v1beta1";
     const GROUP: &'static str = "certificates.k8s.io";
     const KIND: &'static str = "CertificateSigningRequest";
+    const PLURAL_NAME: &'static str = "certificatesigningrequests";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CertificateSigningRequest {

--- a/src/v1_11/api/core/v1/binding.rs
+++ b/src/v1_11/api/core/v1/binding.rs
@@ -106,7 +106,10 @@ impl crate::Resource for Binding {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Binding";
+    const PLURAL_NAME: &'static str = "bindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for Binding {

--- a/src/v1_11/api/core/v1/component_status.rs
+++ b/src/v1_11/api/core/v1/component_status.rs
@@ -170,7 +170,10 @@ impl crate::Resource for ComponentStatus {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ComponentStatus";
+    const PLURAL_NAME: &'static str = "componentstatuses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ComponentStatus {

--- a/src/v1_11/api/core/v1/config_map.rs
+++ b/src/v1_11/api/core/v1/config_map.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ConfigMap {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ConfigMap";
+    const PLURAL_NAME: &'static str = "configmaps";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ConfigMap {

--- a/src/v1_11/api/core/v1/endpoints.rs
+++ b/src/v1_11/api/core/v1/endpoints.rs
@@ -500,7 +500,10 @@ impl crate::Resource for Endpoints {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Endpoints";
+    const PLURAL_NAME: &'static str = "endpoints";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Endpoints {

--- a/src/v1_11/api/core/v1/event.rs
+++ b/src/v1_11/api/core/v1/event.rs
@@ -528,7 +528,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_11/api/core/v1/limit_range.rs
+++ b/src/v1_11/api/core/v1/limit_range.rs
@@ -489,7 +489,10 @@ impl crate::Resource for LimitRange {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "LimitRange";
+    const PLURAL_NAME: &'static str = "limitranges";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for LimitRange {

--- a/src/v1_11/api/core/v1/namespace.rs
+++ b/src/v1_11/api/core/v1/namespace.rs
@@ -555,7 +555,10 @@ impl crate::Resource for Namespace {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Namespace";
+    const PLURAL_NAME: &'static str = "namespaces";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for Namespace {

--- a/src/v1_11/api/core/v1/node.rs
+++ b/src/v1_11/api/core/v1/node.rs
@@ -1030,7 +1030,10 @@ impl crate::Resource for Node {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Node";
+    const PLURAL_NAME: &'static str = "nodes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for Node {

--- a/src/v1_11/api/core/v1/persistent_volume.rs
+++ b/src/v1_11/api/core/v1/persistent_volume.rs
@@ -550,7 +550,10 @@ impl crate::Resource for PersistentVolume {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PersistentVolume";
+    const PLURAL_NAME: &'static str = "persistentvolumes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PersistentVolume {

--- a/src/v1_11/api/core/v1/persistent_volume_claim.rs
+++ b/src/v1_11/api/core/v1/persistent_volume_claim.rs
@@ -684,7 +684,10 @@ impl crate::Resource for PersistentVolumeClaim {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PersistentVolumeClaim";
+    const PLURAL_NAME: &'static str = "persistentvolumeclaims";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PersistentVolumeClaim {

--- a/src/v1_11/api/core/v1/pod.rs
+++ b/src/v1_11/api/core/v1/pod.rs
@@ -1784,7 +1784,10 @@ impl crate::Resource for Pod {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Pod";
+    const PLURAL_NAME: &'static str = "pods";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Pod {

--- a/src/v1_11/api/core/v1/pod_template.rs
+++ b/src/v1_11/api/core/v1/pod_template.rs
@@ -489,7 +489,10 @@ impl crate::Resource for PodTemplate {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PodTemplate";
+    const PLURAL_NAME: &'static str = "podtemplates";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodTemplate {

--- a/src/v1_11/api/core/v1/replication_controller.rs
+++ b/src/v1_11/api/core/v1/replication_controller.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicationController {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ReplicationController";
+    const PLURAL_NAME: &'static str = "replicationcontrollers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicationController {

--- a/src/v1_11/api/core/v1/resource_quota.rs
+++ b/src/v1_11/api/core/v1/resource_quota.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ResourceQuota {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ResourceQuota";
+    const PLURAL_NAME: &'static str = "resourcequotas";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ResourceQuota {

--- a/src/v1_11/api/core/v1/secret.rs
+++ b/src/v1_11/api/core/v1/secret.rs
@@ -495,7 +495,10 @@ impl crate::Resource for Secret {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Secret";
+    const PLURAL_NAME: &'static str = "secrets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Secret {

--- a/src/v1_11/api/core/v1/service.rs
+++ b/src/v1_11/api/core/v1/service.rs
@@ -1181,7 +1181,10 @@ impl crate::Resource for Service {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Service";
+    const PLURAL_NAME: &'static str = "services";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Service {

--- a/src/v1_11/api/core/v1/service_account.rs
+++ b/src/v1_11/api/core/v1/service_account.rs
@@ -495,7 +495,10 @@ impl crate::Resource for ServiceAccount {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ServiceAccount";
+    const PLURAL_NAME: &'static str = "serviceaccounts";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ServiceAccount {

--- a/src/v1_11/api/events/v1beta1/event.rs
+++ b/src/v1_11/api/events/v1beta1/event.rs
@@ -527,7 +527,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "events.k8s.io/v1beta1";
     const GROUP: &'static str = "events.k8s.io";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_11/api/extensions/v1beta1/daemon_set.rs
+++ b/src/v1_11/api/extensions/v1beta1/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_11/api/extensions/v1beta1/deployment.rs
+++ b/src/v1_11/api/extensions/v1beta1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_11/api/extensions/v1beta1/deployment_rollback.rs
+++ b/src/v1_11/api/extensions/v1beta1/deployment_rollback.rs
@@ -68,7 +68,10 @@ impl crate::Resource for DeploymentRollback {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "DeploymentRollback";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for DeploymentRollback {

--- a/src/v1_11/api/extensions/v1beta1/ingress.rs
+++ b/src/v1_11/api/extensions/v1beta1/ingress.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Ingress {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Ingress";
+    const PLURAL_NAME: &'static str = "ingresses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Ingress {

--- a/src/v1_11/api/extensions/v1beta1/network_policy.rs
+++ b/src/v1_11/api/extensions/v1beta1/network_policy.rs
@@ -489,7 +489,10 @@ impl crate::Resource for NetworkPolicy {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "NetworkPolicy";
+    const PLURAL_NAME: &'static str = "networkpolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for NetworkPolicy {

--- a/src/v1_11/api/extensions/v1beta1/pod_security_policy.rs
+++ b/src/v1_11/api/extensions/v1beta1/pod_security_policy.rs
@@ -373,7 +373,10 @@ impl crate::Resource for PodSecurityPolicy {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "PodSecurityPolicy";
+    const PLURAL_NAME: &'static str = "podsecuritypolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PodSecurityPolicy {

--- a/src/v1_11/api/extensions/v1beta1/replica_set.rs
+++ b/src/v1_11/api/extensions/v1beta1/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_11/api/extensions/v1beta1/scale.rs
+++ b/src/v1_11/api/extensions/v1beta1/scale.rs
@@ -597,7 +597,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_11/api/networking/v1/network_policy.rs
+++ b/src/v1_11/api/networking/v1/network_policy.rs
@@ -489,7 +489,10 @@ impl crate::Resource for NetworkPolicy {
     const API_VERSION: &'static str = "networking.k8s.io/v1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "NetworkPolicy";
+    const PLURAL_NAME: &'static str = "networkpolicies";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for NetworkPolicy {

--- a/src/v1_11/api/policy/v1beta1/eviction.rs
+++ b/src/v1_11/api/policy/v1beta1/eviction.rs
@@ -65,7 +65,10 @@ impl crate::Resource for Eviction {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "Eviction";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Eviction {

--- a/src/v1_11/api/policy/v1beta1/pod_disruption_budget.rs
+++ b/src/v1_11/api/policy/v1beta1/pod_disruption_budget.rs
@@ -683,7 +683,10 @@ impl crate::Resource for PodDisruptionBudget {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "PodDisruptionBudget";
+    const PLURAL_NAME: &'static str = "poddisruptionbudgets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodDisruptionBudget {

--- a/src/v1_11/api/policy/v1beta1/pod_security_policy.rs
+++ b/src/v1_11/api/policy/v1beta1/pod_security_policy.rs
@@ -373,7 +373,10 @@ impl crate::Resource for PodSecurityPolicy {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "PodSecurityPolicy";
+    const PLURAL_NAME: &'static str = "podsecuritypolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PodSecurityPolicy {

--- a/src/v1_11/api/rbac/v1/cluster_role.rs
+++ b/src/v1_11/api/rbac/v1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_11/api/rbac/v1/cluster_role_binding.rs
+++ b/src/v1_11/api/rbac/v1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_11/api/rbac/v1/role.rs
+++ b/src/v1_11/api/rbac/v1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_11/api/rbac/v1/role_binding.rs
+++ b/src/v1_11/api/rbac/v1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_11/api/rbac/v1alpha1/cluster_role.rs
+++ b/src/v1_11/api/rbac/v1alpha1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_11/api/rbac/v1alpha1/cluster_role_binding.rs
+++ b/src/v1_11/api/rbac/v1alpha1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_11/api/rbac/v1alpha1/role.rs
+++ b/src/v1_11/api/rbac/v1alpha1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_11/api/rbac/v1alpha1/role_binding.rs
+++ b/src/v1_11/api/rbac/v1alpha1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_11/api/rbac/v1beta1/cluster_role.rs
+++ b/src/v1_11/api/rbac/v1beta1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_11/api/rbac/v1beta1/cluster_role_binding.rs
+++ b/src/v1_11/api/rbac/v1beta1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_11/api/rbac/v1beta1/role.rs
+++ b/src/v1_11/api/rbac/v1beta1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_11/api/rbac/v1beta1/role_binding.rs
+++ b/src/v1_11/api/rbac/v1beta1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_11/api/scheduling/v1alpha1/priority_class.rs
+++ b/src/v1_11/api/scheduling/v1alpha1/priority_class.rs
@@ -379,7 +379,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1alpha1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_11/api/scheduling/v1beta1/priority_class.rs
+++ b/src/v1_11/api/scheduling/v1beta1/priority_class.rs
@@ -379,7 +379,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1beta1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_11/api/settings/v1alpha1/pod_preset.rs
+++ b/src/v1_11/api/settings/v1alpha1/pod_preset.rs
@@ -487,7 +487,10 @@ impl crate::Resource for PodPreset {
     const API_VERSION: &'static str = "settings.k8s.io/v1alpha1";
     const GROUP: &'static str = "settings.k8s.io";
     const KIND: &'static str = "PodPreset";
+    const PLURAL_NAME: &'static str = "podpresets";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodPreset {

--- a/src/v1_11/api/storage/v1/storage_class.rs
+++ b/src/v1_11/api/storage/v1/storage_class.rs
@@ -393,7 +393,10 @@ impl crate::Resource for StorageClass {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "StorageClass";
+    const PLURAL_NAME: &'static str = "storageclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageClass {

--- a/src/v1_11/api/storage/v1alpha1/volume_attachment.rs
+++ b/src/v1_11/api/storage/v1alpha1/volume_attachment.rs
@@ -378,7 +378,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1alpha1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_11/api/storage/v1beta1/storage_class.rs
+++ b/src/v1_11/api/storage/v1beta1/storage_class.rs
@@ -393,7 +393,10 @@ impl crate::Resource for StorageClass {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "StorageClass";
+    const PLURAL_NAME: &'static str = "storageclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageClass {

--- a/src/v1_11/api/storage/v1beta1/volume_attachment.rs
+++ b/src/v1_11/api/storage/v1beta1/volume_attachment.rs
@@ -378,7 +378,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_11/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
+++ b/src/v1_11/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
@@ -549,7 +549,10 @@ impl crate::Resource for CustomResourceDefinition {
     const API_VERSION: &'static str = "apiextensions.k8s.io/v1beta1";
     const GROUP: &'static str = "apiextensions.k8s.io";
     const KIND: &'static str = "CustomResourceDefinition";
+    const PLURAL_NAME: &'static str = "customresourcedefinitions";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CustomResourceDefinition {

--- a/src/v1_11/apimachinery/pkg/apis/meta/v1/api_group.rs
+++ b/src/v1_11/apimachinery/pkg/apis/meta/v1/api_group.rs
@@ -20,7 +20,10 @@ impl crate::Resource for APIGroup {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIGroup";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIGroup {

--- a/src/v1_11/apimachinery/pkg/apis/meta/v1/api_group_list.rs
+++ b/src/v1_11/apimachinery/pkg/apis/meta/v1/api_group_list.rs
@@ -11,7 +11,10 @@ impl crate::Resource for APIGroupList {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIGroupList";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIGroupList {

--- a/src/v1_11/apimachinery/pkg/apis/meta/v1/api_resource_list.rs
+++ b/src/v1_11/apimachinery/pkg/apis/meta/v1/api_resource_list.rs
@@ -14,7 +14,10 @@ impl crate::Resource for APIResourceList {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIResourceList";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIResourceList {

--- a/src/v1_11/apimachinery/pkg/apis/meta/v1/api_versions.rs
+++ b/src/v1_11/apimachinery/pkg/apis/meta/v1/api_versions.rs
@@ -14,7 +14,10 @@ impl crate::Resource for APIVersions {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIVersions";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIVersions {

--- a/src/v1_11/apimachinery/pkg/apis/meta/v1/status.rs
+++ b/src/v1_11/apimachinery/pkg/apis/meta/v1/status.rs
@@ -26,7 +26,10 @@ impl crate::Resource for Status {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Status";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Status {

--- a/src/v1_11/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
+++ b/src/v1_11/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
@@ -549,7 +549,10 @@ impl crate::Resource for APIService {
     const API_VERSION: &'static str = "apiregistration.k8s.io/v1";
     const GROUP: &'static str = "apiregistration.k8s.io";
     const KIND: &'static str = "APIService";
+    const PLURAL_NAME: &'static str = "apiservices";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for APIService {

--- a/src/v1_11/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
+++ b/src/v1_11/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
@@ -549,7 +549,10 @@ impl crate::Resource for APIService {
     const API_VERSION: &'static str = "apiregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "apiregistration.k8s.io";
     const KIND: &'static str = "APIService";
+    const PLURAL_NAME: &'static str = "apiservices";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for APIService {

--- a/src/v1_11/list.rs
+++ b/src/v1_11/list.rs
@@ -14,7 +14,10 @@ impl<T> crate::Resource for List<T> where T: crate::ListableResource {
     const API_VERSION: &'static str = <T as crate::Resource>::API_VERSION;
     const GROUP: &'static str = <T as crate::Resource>::GROUP;
     const KIND: &'static str = <T as crate::ListableResource>::LIST_KIND;
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = <T as crate::Resource>::VERSION;
+    const NAMESPACED: bool = <T as crate::Resource>::NAMESPACED;
+    type Scope = <T as crate::Resource>::Scope;
 }
 
 impl<T> crate::Metadata for List<T> where T: crate::ListableResource {

--- a/src/v1_12/api/admissionregistration/v1alpha1/initializer_configuration.rs
+++ b/src/v1_12/api/admissionregistration/v1alpha1/initializer_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for InitializerConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1alpha1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "InitializerConfiguration";
+    const PLURAL_NAME: &'static str = "initializerconfigurations";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for InitializerConfiguration {

--- a/src/v1_12/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
+++ b/src/v1_12/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for MutatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "MutatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "mutatingwebhookconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for MutatingWebhookConfiguration {

--- a/src/v1_12/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
+++ b/src/v1_12/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for ValidatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "ValidatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "validatingwebhookconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ValidatingWebhookConfiguration {

--- a/src/v1_12/api/apps/v1/controller_revision.rs
+++ b/src/v1_12/api/apps/v1/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_12/api/apps/v1/daemon_set.rs
+++ b/src/v1_12/api/apps/v1/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_12/api/apps/v1/deployment.rs
+++ b/src/v1_12/api/apps/v1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_12/api/apps/v1/replica_set.rs
+++ b/src/v1_12/api/apps/v1/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_12/api/apps/v1/stateful_set.rs
+++ b/src/v1_12/api/apps/v1/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_12/api/apps/v1beta1/controller_revision.rs
+++ b/src/v1_12/api/apps/v1beta1/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_12/api/apps/v1beta1/deployment.rs
+++ b/src/v1_12/api/apps/v1beta1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_12/api/apps/v1beta1/deployment_rollback.rs
+++ b/src/v1_12/api/apps/v1beta1/deployment_rollback.rs
@@ -124,7 +124,10 @@ impl crate::Resource for DeploymentRollback {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DeploymentRollback";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for DeploymentRollback {

--- a/src/v1_12/api/apps/v1beta1/scale.rs
+++ b/src/v1_12/api/apps/v1beta1/scale.rs
@@ -405,7 +405,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_12/api/apps/v1beta1/stateful_set.rs
+++ b/src/v1_12/api/apps/v1beta1/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_12/api/apps/v1beta2/controller_revision.rs
+++ b/src/v1_12/api/apps/v1beta2/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_12/api/apps/v1beta2/daemon_set.rs
+++ b/src/v1_12/api/apps/v1beta2/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_12/api/apps/v1beta2/deployment.rs
+++ b/src/v1_12/api/apps/v1beta2/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_12/api/apps/v1beta2/replica_set.rs
+++ b/src/v1_12/api/apps/v1beta2/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_12/api/apps/v1beta2/scale.rs
+++ b/src/v1_12/api/apps/v1beta2/scale.rs
@@ -597,7 +597,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_12/api/apps/v1beta2/stateful_set.rs
+++ b/src/v1_12/api/apps/v1beta2/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_12/api/authentication/v1/token_review.rs
+++ b/src/v1_12/api/authentication/v1/token_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for TokenReview {
     const API_VERSION: &'static str = "authentication.k8s.io/v1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenReview";
+    const PLURAL_NAME: &'static str = "tokenreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenReview {

--- a/src/v1_12/api/authentication/v1beta1/token_review.rs
+++ b/src/v1_12/api/authentication/v1beta1/token_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for TokenReview {
     const API_VERSION: &'static str = "authentication.k8s.io/v1beta1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenReview";
+    const PLURAL_NAME: &'static str = "tokenreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenReview {

--- a/src/v1_12/api/authorization/v1/local_subject_access_review.rs
+++ b/src/v1_12/api/authorization/v1/local_subject_access_review.rs
@@ -61,7 +61,10 @@ impl crate::Resource for LocalSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "LocalSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "localsubjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for LocalSubjectAccessReview {

--- a/src/v1_12/api/authorization/v1/self_subject_access_review.rs
+++ b/src/v1_12/api/authorization/v1/self_subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "selfsubjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectAccessReview {

--- a/src/v1_12/api/authorization/v1/self_subject_rules_review.rs
+++ b/src/v1_12/api/authorization/v1/self_subject_rules_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectRulesReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectRulesReview";
+    const PLURAL_NAME: &'static str = "selfsubjectrulesreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectRulesReview {

--- a/src/v1_12/api/authorization/v1/subject_access_review.rs
+++ b/src/v1_12/api/authorization/v1/subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SubjectAccessReview";
+    const PLURAL_NAME: &'static str = "subjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SubjectAccessReview {

--- a/src/v1_12/api/authorization/v1beta1/local_subject_access_review.rs
+++ b/src/v1_12/api/authorization/v1beta1/local_subject_access_review.rs
@@ -61,7 +61,10 @@ impl crate::Resource for LocalSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "LocalSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "localsubjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for LocalSubjectAccessReview {

--- a/src/v1_12/api/authorization/v1beta1/self_subject_access_review.rs
+++ b/src/v1_12/api/authorization/v1beta1/self_subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "selfsubjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectAccessReview {

--- a/src/v1_12/api/authorization/v1beta1/self_subject_rules_review.rs
+++ b/src/v1_12/api/authorization/v1beta1/self_subject_rules_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectRulesReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectRulesReview";
+    const PLURAL_NAME: &'static str = "selfsubjectrulesreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectRulesReview {

--- a/src/v1_12/api/authorization/v1beta1/subject_access_review.rs
+++ b/src/v1_12/api/authorization/v1beta1/subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SubjectAccessReview";
+    const PLURAL_NAME: &'static str = "subjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SubjectAccessReview {

--- a/src/v1_12/api/autoscaling/v1/horizontal_pod_autoscaler.rs
+++ b/src/v1_12/api/autoscaling/v1/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_12/api/autoscaling/v1/scale.rs
+++ b/src/v1_12/api/autoscaling/v1/scale.rs
@@ -789,7 +789,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "autoscaling/v1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_12/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
+++ b/src/v1_12/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v2beta1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v2beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_12/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
+++ b/src/v1_12/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v2beta2";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v2beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_12/api/batch/v1/job.rs
+++ b/src/v1_12/api/batch/v1/job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Job {
     const API_VERSION: &'static str = "batch/v1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "Job";
+    const PLURAL_NAME: &'static str = "jobs";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Job {

--- a/src/v1_12/api/batch/v1beta1/cron_job.rs
+++ b/src/v1_12/api/batch/v1beta1/cron_job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for CronJob {
     const API_VERSION: &'static str = "batch/v1beta1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "CronJob";
+    const PLURAL_NAME: &'static str = "cronjobs";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CronJob {

--- a/src/v1_12/api/batch/v2alpha1/cron_job.rs
+++ b/src/v1_12/api/batch/v2alpha1/cron_job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for CronJob {
     const API_VERSION: &'static str = "batch/v2alpha1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "CronJob";
+    const PLURAL_NAME: &'static str = "cronjobs";
     const VERSION: &'static str = "v2alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CronJob {

--- a/src/v1_12/api/certificates/v1beta1/certificate_signing_request.rs
+++ b/src/v1_12/api/certificates/v1beta1/certificate_signing_request.rs
@@ -590,7 +590,10 @@ impl crate::Resource for CertificateSigningRequest {
     const API_VERSION: &'static str = "certificates.k8s.io/v1beta1";
     const GROUP: &'static str = "certificates.k8s.io";
     const KIND: &'static str = "CertificateSigningRequest";
+    const PLURAL_NAME: &'static str = "certificatesigningrequests";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CertificateSigningRequest {

--- a/src/v1_12/api/coordination/v1beta1/lease.rs
+++ b/src/v1_12/api/coordination/v1beta1/lease.rs
@@ -489,7 +489,10 @@ impl crate::Resource for Lease {
     const API_VERSION: &'static str = "coordination.k8s.io/v1beta1";
     const GROUP: &'static str = "coordination.k8s.io";
     const KIND: &'static str = "Lease";
+    const PLURAL_NAME: &'static str = "leases";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Lease {

--- a/src/v1_12/api/core/v1/binding.rs
+++ b/src/v1_12/api/core/v1/binding.rs
@@ -106,7 +106,10 @@ impl crate::Resource for Binding {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Binding";
+    const PLURAL_NAME: &'static str = "bindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for Binding {

--- a/src/v1_12/api/core/v1/component_status.rs
+++ b/src/v1_12/api/core/v1/component_status.rs
@@ -170,7 +170,10 @@ impl crate::Resource for ComponentStatus {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ComponentStatus";
+    const PLURAL_NAME: &'static str = "componentstatuses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ComponentStatus {

--- a/src/v1_12/api/core/v1/config_map.rs
+++ b/src/v1_12/api/core/v1/config_map.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ConfigMap {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ConfigMap";
+    const PLURAL_NAME: &'static str = "configmaps";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ConfigMap {

--- a/src/v1_12/api/core/v1/endpoints.rs
+++ b/src/v1_12/api/core/v1/endpoints.rs
@@ -500,7 +500,10 @@ impl crate::Resource for Endpoints {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Endpoints";
+    const PLURAL_NAME: &'static str = "endpoints";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Endpoints {

--- a/src/v1_12/api/core/v1/event.rs
+++ b/src/v1_12/api/core/v1/event.rs
@@ -528,7 +528,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_12/api/core/v1/limit_range.rs
+++ b/src/v1_12/api/core/v1/limit_range.rs
@@ -489,7 +489,10 @@ impl crate::Resource for LimitRange {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "LimitRange";
+    const PLURAL_NAME: &'static str = "limitranges";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for LimitRange {

--- a/src/v1_12/api/core/v1/namespace.rs
+++ b/src/v1_12/api/core/v1/namespace.rs
@@ -555,7 +555,10 @@ impl crate::Resource for Namespace {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Namespace";
+    const PLURAL_NAME: &'static str = "namespaces";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for Namespace {

--- a/src/v1_12/api/core/v1/node.rs
+++ b/src/v1_12/api/core/v1/node.rs
@@ -1030,7 +1030,10 @@ impl crate::Resource for Node {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Node";
+    const PLURAL_NAME: &'static str = "nodes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for Node {

--- a/src/v1_12/api/core/v1/persistent_volume.rs
+++ b/src/v1_12/api/core/v1/persistent_volume.rs
@@ -550,7 +550,10 @@ impl crate::Resource for PersistentVolume {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PersistentVolume";
+    const PLURAL_NAME: &'static str = "persistentvolumes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PersistentVolume {

--- a/src/v1_12/api/core/v1/persistent_volume_claim.rs
+++ b/src/v1_12/api/core/v1/persistent_volume_claim.rs
@@ -684,7 +684,10 @@ impl crate::Resource for PersistentVolumeClaim {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PersistentVolumeClaim";
+    const PLURAL_NAME: &'static str = "persistentvolumeclaims";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PersistentVolumeClaim {

--- a/src/v1_12/api/core/v1/pod.rs
+++ b/src/v1_12/api/core/v1/pod.rs
@@ -1784,7 +1784,10 @@ impl crate::Resource for Pod {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Pod";
+    const PLURAL_NAME: &'static str = "pods";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Pod {

--- a/src/v1_12/api/core/v1/pod_template.rs
+++ b/src/v1_12/api/core/v1/pod_template.rs
@@ -489,7 +489,10 @@ impl crate::Resource for PodTemplate {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PodTemplate";
+    const PLURAL_NAME: &'static str = "podtemplates";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodTemplate {

--- a/src/v1_12/api/core/v1/replication_controller.rs
+++ b/src/v1_12/api/core/v1/replication_controller.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicationController {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ReplicationController";
+    const PLURAL_NAME: &'static str = "replicationcontrollers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicationController {

--- a/src/v1_12/api/core/v1/resource_quota.rs
+++ b/src/v1_12/api/core/v1/resource_quota.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ResourceQuota {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ResourceQuota";
+    const PLURAL_NAME: &'static str = "resourcequotas";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ResourceQuota {

--- a/src/v1_12/api/core/v1/secret.rs
+++ b/src/v1_12/api/core/v1/secret.rs
@@ -495,7 +495,10 @@ impl crate::Resource for Secret {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Secret";
+    const PLURAL_NAME: &'static str = "secrets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Secret {

--- a/src/v1_12/api/core/v1/service.rs
+++ b/src/v1_12/api/core/v1/service.rs
@@ -1181,7 +1181,10 @@ impl crate::Resource for Service {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Service";
+    const PLURAL_NAME: &'static str = "services";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Service {

--- a/src/v1_12/api/core/v1/service_account.rs
+++ b/src/v1_12/api/core/v1/service_account.rs
@@ -495,7 +495,10 @@ impl crate::Resource for ServiceAccount {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ServiceAccount";
+    const PLURAL_NAME: &'static str = "serviceaccounts";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ServiceAccount {

--- a/src/v1_12/api/events/v1beta1/event.rs
+++ b/src/v1_12/api/events/v1beta1/event.rs
@@ -527,7 +527,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "events.k8s.io/v1beta1";
     const GROUP: &'static str = "events.k8s.io";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_12/api/extensions/v1beta1/daemon_set.rs
+++ b/src/v1_12/api/extensions/v1beta1/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_12/api/extensions/v1beta1/deployment.rs
+++ b/src/v1_12/api/extensions/v1beta1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_12/api/extensions/v1beta1/deployment_rollback.rs
+++ b/src/v1_12/api/extensions/v1beta1/deployment_rollback.rs
@@ -124,7 +124,10 @@ impl crate::Resource for DeploymentRollback {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "DeploymentRollback";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for DeploymentRollback {

--- a/src/v1_12/api/extensions/v1beta1/ingress.rs
+++ b/src/v1_12/api/extensions/v1beta1/ingress.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Ingress {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Ingress";
+    const PLURAL_NAME: &'static str = "ingresses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Ingress {

--- a/src/v1_12/api/extensions/v1beta1/network_policy.rs
+++ b/src/v1_12/api/extensions/v1beta1/network_policy.rs
@@ -489,7 +489,10 @@ impl crate::Resource for NetworkPolicy {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "NetworkPolicy";
+    const PLURAL_NAME: &'static str = "networkpolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for NetworkPolicy {

--- a/src/v1_12/api/extensions/v1beta1/pod_security_policy.rs
+++ b/src/v1_12/api/extensions/v1beta1/pod_security_policy.rs
@@ -373,7 +373,10 @@ impl crate::Resource for PodSecurityPolicy {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "PodSecurityPolicy";
+    const PLURAL_NAME: &'static str = "podsecuritypolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PodSecurityPolicy {

--- a/src/v1_12/api/extensions/v1beta1/replica_set.rs
+++ b/src/v1_12/api/extensions/v1beta1/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_12/api/extensions/v1beta1/scale.rs
+++ b/src/v1_12/api/extensions/v1beta1/scale.rs
@@ -597,7 +597,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_12/api/networking/v1/network_policy.rs
+++ b/src/v1_12/api/networking/v1/network_policy.rs
@@ -489,7 +489,10 @@ impl crate::Resource for NetworkPolicy {
     const API_VERSION: &'static str = "networking.k8s.io/v1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "NetworkPolicy";
+    const PLURAL_NAME: &'static str = "networkpolicies";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for NetworkPolicy {

--- a/src/v1_12/api/policy/v1beta1/eviction.rs
+++ b/src/v1_12/api/policy/v1beta1/eviction.rs
@@ -65,7 +65,10 @@ impl crate::Resource for Eviction {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "Eviction";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Eviction {

--- a/src/v1_12/api/policy/v1beta1/pod_disruption_budget.rs
+++ b/src/v1_12/api/policy/v1beta1/pod_disruption_budget.rs
@@ -683,7 +683,10 @@ impl crate::Resource for PodDisruptionBudget {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "PodDisruptionBudget";
+    const PLURAL_NAME: &'static str = "poddisruptionbudgets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodDisruptionBudget {

--- a/src/v1_12/api/policy/v1beta1/pod_security_policy.rs
+++ b/src/v1_12/api/policy/v1beta1/pod_security_policy.rs
@@ -373,7 +373,10 @@ impl crate::Resource for PodSecurityPolicy {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "PodSecurityPolicy";
+    const PLURAL_NAME: &'static str = "podsecuritypolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PodSecurityPolicy {

--- a/src/v1_12/api/rbac/v1/cluster_role.rs
+++ b/src/v1_12/api/rbac/v1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_12/api/rbac/v1/cluster_role_binding.rs
+++ b/src/v1_12/api/rbac/v1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_12/api/rbac/v1/role.rs
+++ b/src/v1_12/api/rbac/v1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_12/api/rbac/v1/role_binding.rs
+++ b/src/v1_12/api/rbac/v1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_12/api/rbac/v1alpha1/cluster_role.rs
+++ b/src/v1_12/api/rbac/v1alpha1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_12/api/rbac/v1alpha1/cluster_role_binding.rs
+++ b/src/v1_12/api/rbac/v1alpha1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_12/api/rbac/v1alpha1/role.rs
+++ b/src/v1_12/api/rbac/v1alpha1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_12/api/rbac/v1alpha1/role_binding.rs
+++ b/src/v1_12/api/rbac/v1alpha1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_12/api/rbac/v1beta1/cluster_role.rs
+++ b/src/v1_12/api/rbac/v1beta1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_12/api/rbac/v1beta1/cluster_role_binding.rs
+++ b/src/v1_12/api/rbac/v1beta1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_12/api/rbac/v1beta1/role.rs
+++ b/src/v1_12/api/rbac/v1beta1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_12/api/rbac/v1beta1/role_binding.rs
+++ b/src/v1_12/api/rbac/v1beta1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_12/api/scheduling/v1alpha1/priority_class.rs
+++ b/src/v1_12/api/scheduling/v1alpha1/priority_class.rs
@@ -379,7 +379,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1alpha1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_12/api/scheduling/v1beta1/priority_class.rs
+++ b/src/v1_12/api/scheduling/v1beta1/priority_class.rs
@@ -379,7 +379,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1beta1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_12/api/settings/v1alpha1/pod_preset.rs
+++ b/src/v1_12/api/settings/v1alpha1/pod_preset.rs
@@ -487,7 +487,10 @@ impl crate::Resource for PodPreset {
     const API_VERSION: &'static str = "settings.k8s.io/v1alpha1";
     const GROUP: &'static str = "settings.k8s.io";
     const KIND: &'static str = "PodPreset";
+    const PLURAL_NAME: &'static str = "podpresets";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodPreset {

--- a/src/v1_12/api/storage/v1/storage_class.rs
+++ b/src/v1_12/api/storage/v1/storage_class.rs
@@ -393,7 +393,10 @@ impl crate::Resource for StorageClass {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "StorageClass";
+    const PLURAL_NAME: &'static str = "storageclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageClass {

--- a/src/v1_12/api/storage/v1alpha1/volume_attachment.rs
+++ b/src/v1_12/api/storage/v1alpha1/volume_attachment.rs
@@ -378,7 +378,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1alpha1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_12/api/storage/v1beta1/storage_class.rs
+++ b/src/v1_12/api/storage/v1beta1/storage_class.rs
@@ -393,7 +393,10 @@ impl crate::Resource for StorageClass {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "StorageClass";
+    const PLURAL_NAME: &'static str = "storageclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageClass {

--- a/src/v1_12/api/storage/v1beta1/volume_attachment.rs
+++ b/src/v1_12/api/storage/v1beta1/volume_attachment.rs
@@ -378,7 +378,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_12/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
+++ b/src/v1_12/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
@@ -549,7 +549,10 @@ impl crate::Resource for CustomResourceDefinition {
     const API_VERSION: &'static str = "apiextensions.k8s.io/v1beta1";
     const GROUP: &'static str = "apiextensions.k8s.io";
     const KIND: &'static str = "CustomResourceDefinition";
+    const PLURAL_NAME: &'static str = "customresourcedefinitions";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CustomResourceDefinition {

--- a/src/v1_12/apimachinery/pkg/apis/meta/v1/api_group.rs
+++ b/src/v1_12/apimachinery/pkg/apis/meta/v1/api_group.rs
@@ -20,7 +20,10 @@ impl crate::Resource for APIGroup {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIGroup";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIGroup {

--- a/src/v1_12/apimachinery/pkg/apis/meta/v1/api_group_list.rs
+++ b/src/v1_12/apimachinery/pkg/apis/meta/v1/api_group_list.rs
@@ -11,7 +11,10 @@ impl crate::Resource for APIGroupList {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIGroupList";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIGroupList {

--- a/src/v1_12/apimachinery/pkg/apis/meta/v1/api_resource_list.rs
+++ b/src/v1_12/apimachinery/pkg/apis/meta/v1/api_resource_list.rs
@@ -14,7 +14,10 @@ impl crate::Resource for APIResourceList {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIResourceList";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIResourceList {

--- a/src/v1_12/apimachinery/pkg/apis/meta/v1/api_versions.rs
+++ b/src/v1_12/apimachinery/pkg/apis/meta/v1/api_versions.rs
@@ -14,7 +14,10 @@ impl crate::Resource for APIVersions {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIVersions";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIVersions {

--- a/src/v1_12/apimachinery/pkg/apis/meta/v1/status.rs
+++ b/src/v1_12/apimachinery/pkg/apis/meta/v1/status.rs
@@ -26,7 +26,10 @@ impl crate::Resource for Status {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Status";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Status {

--- a/src/v1_12/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
+++ b/src/v1_12/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
@@ -549,7 +549,10 @@ impl crate::Resource for APIService {
     const API_VERSION: &'static str = "apiregistration.k8s.io/v1";
     const GROUP: &'static str = "apiregistration.k8s.io";
     const KIND: &'static str = "APIService";
+    const PLURAL_NAME: &'static str = "apiservices";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for APIService {

--- a/src/v1_12/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
+++ b/src/v1_12/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
@@ -549,7 +549,10 @@ impl crate::Resource for APIService {
     const API_VERSION: &'static str = "apiregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "apiregistration.k8s.io";
     const KIND: &'static str = "APIService";
+    const PLURAL_NAME: &'static str = "apiservices";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for APIService {

--- a/src/v1_12/list.rs
+++ b/src/v1_12/list.rs
@@ -14,7 +14,10 @@ impl<T> crate::Resource for List<T> where T: crate::ListableResource {
     const API_VERSION: &'static str = <T as crate::Resource>::API_VERSION;
     const GROUP: &'static str = <T as crate::Resource>::GROUP;
     const KIND: &'static str = <T as crate::ListableResource>::LIST_KIND;
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = <T as crate::Resource>::VERSION;
+    const NAMESPACED: bool = <T as crate::Resource>::NAMESPACED;
+    type Scope = <T as crate::Resource>::Scope;
 }
 
 impl<T> crate::Metadata for List<T> where T: crate::ListableResource {

--- a/src/v1_13/api/admissionregistration/v1alpha1/initializer_configuration.rs
+++ b/src/v1_13/api/admissionregistration/v1alpha1/initializer_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for InitializerConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1alpha1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "InitializerConfiguration";
+    const PLURAL_NAME: &'static str = "initializerconfigurations";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for InitializerConfiguration {

--- a/src/v1_13/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
+++ b/src/v1_13/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for MutatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "MutatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "mutatingwebhookconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for MutatingWebhookConfiguration {

--- a/src/v1_13/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
+++ b/src/v1_13/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for ValidatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "ValidatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "validatingwebhookconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ValidatingWebhookConfiguration {

--- a/src/v1_13/api/apps/v1/controller_revision.rs
+++ b/src/v1_13/api/apps/v1/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_13/api/apps/v1/daemon_set.rs
+++ b/src/v1_13/api/apps/v1/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_13/api/apps/v1/deployment.rs
+++ b/src/v1_13/api/apps/v1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_13/api/apps/v1/replica_set.rs
+++ b/src/v1_13/api/apps/v1/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_13/api/apps/v1/stateful_set.rs
+++ b/src/v1_13/api/apps/v1/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_13/api/apps/v1beta1/controller_revision.rs
+++ b/src/v1_13/api/apps/v1beta1/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_13/api/apps/v1beta1/deployment.rs
+++ b/src/v1_13/api/apps/v1beta1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_13/api/apps/v1beta1/deployment_rollback.rs
+++ b/src/v1_13/api/apps/v1beta1/deployment_rollback.rs
@@ -124,7 +124,10 @@ impl crate::Resource for DeploymentRollback {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DeploymentRollback";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for DeploymentRollback {

--- a/src/v1_13/api/apps/v1beta1/scale.rs
+++ b/src/v1_13/api/apps/v1beta1/scale.rs
@@ -405,7 +405,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_13/api/apps/v1beta1/stateful_set.rs
+++ b/src/v1_13/api/apps/v1beta1/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_13/api/apps/v1beta2/controller_revision.rs
+++ b/src/v1_13/api/apps/v1beta2/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_13/api/apps/v1beta2/daemon_set.rs
+++ b/src/v1_13/api/apps/v1beta2/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_13/api/apps/v1beta2/deployment.rs
+++ b/src/v1_13/api/apps/v1beta2/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_13/api/apps/v1beta2/replica_set.rs
+++ b/src/v1_13/api/apps/v1beta2/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_13/api/apps/v1beta2/scale.rs
+++ b/src/v1_13/api/apps/v1beta2/scale.rs
@@ -597,7 +597,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_13/api/apps/v1beta2/stateful_set.rs
+++ b/src/v1_13/api/apps/v1beta2/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_13/api/auditregistration/v1alpha1/audit_sink.rs
+++ b/src/v1_13/api/auditregistration/v1alpha1/audit_sink.rs
@@ -372,7 +372,10 @@ impl crate::Resource for AuditSink {
     const API_VERSION: &'static str = "auditregistration.k8s.io/v1alpha1";
     const GROUP: &'static str = "auditregistration.k8s.io";
     const KIND: &'static str = "AuditSink";
+    const PLURAL_NAME: &'static str = "auditsinks";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for AuditSink {

--- a/src/v1_13/api/authentication/v1/token_review.rs
+++ b/src/v1_13/api/authentication/v1/token_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for TokenReview {
     const API_VERSION: &'static str = "authentication.k8s.io/v1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenReview";
+    const PLURAL_NAME: &'static str = "tokenreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenReview {

--- a/src/v1_13/api/authentication/v1beta1/token_review.rs
+++ b/src/v1_13/api/authentication/v1beta1/token_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for TokenReview {
     const API_VERSION: &'static str = "authentication.k8s.io/v1beta1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenReview";
+    const PLURAL_NAME: &'static str = "tokenreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenReview {

--- a/src/v1_13/api/authorization/v1/local_subject_access_review.rs
+++ b/src/v1_13/api/authorization/v1/local_subject_access_review.rs
@@ -61,7 +61,10 @@ impl crate::Resource for LocalSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "LocalSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "localsubjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for LocalSubjectAccessReview {

--- a/src/v1_13/api/authorization/v1/self_subject_access_review.rs
+++ b/src/v1_13/api/authorization/v1/self_subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "selfsubjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectAccessReview {

--- a/src/v1_13/api/authorization/v1/self_subject_rules_review.rs
+++ b/src/v1_13/api/authorization/v1/self_subject_rules_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectRulesReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectRulesReview";
+    const PLURAL_NAME: &'static str = "selfsubjectrulesreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectRulesReview {

--- a/src/v1_13/api/authorization/v1/subject_access_review.rs
+++ b/src/v1_13/api/authorization/v1/subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SubjectAccessReview";
+    const PLURAL_NAME: &'static str = "subjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SubjectAccessReview {

--- a/src/v1_13/api/authorization/v1beta1/local_subject_access_review.rs
+++ b/src/v1_13/api/authorization/v1beta1/local_subject_access_review.rs
@@ -61,7 +61,10 @@ impl crate::Resource for LocalSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "LocalSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "localsubjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for LocalSubjectAccessReview {

--- a/src/v1_13/api/authorization/v1beta1/self_subject_access_review.rs
+++ b/src/v1_13/api/authorization/v1beta1/self_subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "selfsubjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectAccessReview {

--- a/src/v1_13/api/authorization/v1beta1/self_subject_rules_review.rs
+++ b/src/v1_13/api/authorization/v1beta1/self_subject_rules_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectRulesReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectRulesReview";
+    const PLURAL_NAME: &'static str = "selfsubjectrulesreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectRulesReview {

--- a/src/v1_13/api/authorization/v1beta1/subject_access_review.rs
+++ b/src/v1_13/api/authorization/v1beta1/subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SubjectAccessReview";
+    const PLURAL_NAME: &'static str = "subjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SubjectAccessReview {

--- a/src/v1_13/api/autoscaling/v1/horizontal_pod_autoscaler.rs
+++ b/src/v1_13/api/autoscaling/v1/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_13/api/autoscaling/v1/scale.rs
+++ b/src/v1_13/api/autoscaling/v1/scale.rs
@@ -789,7 +789,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "autoscaling/v1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_13/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
+++ b/src/v1_13/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v2beta1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v2beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_13/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
+++ b/src/v1_13/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v2beta2";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v2beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_13/api/batch/v1/job.rs
+++ b/src/v1_13/api/batch/v1/job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Job {
     const API_VERSION: &'static str = "batch/v1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "Job";
+    const PLURAL_NAME: &'static str = "jobs";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Job {

--- a/src/v1_13/api/batch/v1beta1/cron_job.rs
+++ b/src/v1_13/api/batch/v1beta1/cron_job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for CronJob {
     const API_VERSION: &'static str = "batch/v1beta1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "CronJob";
+    const PLURAL_NAME: &'static str = "cronjobs";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CronJob {

--- a/src/v1_13/api/batch/v2alpha1/cron_job.rs
+++ b/src/v1_13/api/batch/v2alpha1/cron_job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for CronJob {
     const API_VERSION: &'static str = "batch/v2alpha1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "CronJob";
+    const PLURAL_NAME: &'static str = "cronjobs";
     const VERSION: &'static str = "v2alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CronJob {

--- a/src/v1_13/api/certificates/v1beta1/certificate_signing_request.rs
+++ b/src/v1_13/api/certificates/v1beta1/certificate_signing_request.rs
@@ -590,7 +590,10 @@ impl crate::Resource for CertificateSigningRequest {
     const API_VERSION: &'static str = "certificates.k8s.io/v1beta1";
     const GROUP: &'static str = "certificates.k8s.io";
     const KIND: &'static str = "CertificateSigningRequest";
+    const PLURAL_NAME: &'static str = "certificatesigningrequests";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CertificateSigningRequest {

--- a/src/v1_13/api/coordination/v1beta1/lease.rs
+++ b/src/v1_13/api/coordination/v1beta1/lease.rs
@@ -489,7 +489,10 @@ impl crate::Resource for Lease {
     const API_VERSION: &'static str = "coordination.k8s.io/v1beta1";
     const GROUP: &'static str = "coordination.k8s.io";
     const KIND: &'static str = "Lease";
+    const PLURAL_NAME: &'static str = "leases";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Lease {

--- a/src/v1_13/api/core/v1/binding.rs
+++ b/src/v1_13/api/core/v1/binding.rs
@@ -106,7 +106,10 @@ impl crate::Resource for Binding {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Binding";
+    const PLURAL_NAME: &'static str = "bindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for Binding {

--- a/src/v1_13/api/core/v1/component_status.rs
+++ b/src/v1_13/api/core/v1/component_status.rs
@@ -170,7 +170,10 @@ impl crate::Resource for ComponentStatus {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ComponentStatus";
+    const PLURAL_NAME: &'static str = "componentstatuses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ComponentStatus {

--- a/src/v1_13/api/core/v1/config_map.rs
+++ b/src/v1_13/api/core/v1/config_map.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ConfigMap {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ConfigMap";
+    const PLURAL_NAME: &'static str = "configmaps";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ConfigMap {

--- a/src/v1_13/api/core/v1/endpoints.rs
+++ b/src/v1_13/api/core/v1/endpoints.rs
@@ -500,7 +500,10 @@ impl crate::Resource for Endpoints {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Endpoints";
+    const PLURAL_NAME: &'static str = "endpoints";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Endpoints {

--- a/src/v1_13/api/core/v1/event.rs
+++ b/src/v1_13/api/core/v1/event.rs
@@ -528,7 +528,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_13/api/core/v1/limit_range.rs
+++ b/src/v1_13/api/core/v1/limit_range.rs
@@ -489,7 +489,10 @@ impl crate::Resource for LimitRange {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "LimitRange";
+    const PLURAL_NAME: &'static str = "limitranges";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for LimitRange {

--- a/src/v1_13/api/core/v1/namespace.rs
+++ b/src/v1_13/api/core/v1/namespace.rs
@@ -555,7 +555,10 @@ impl crate::Resource for Namespace {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Namespace";
+    const PLURAL_NAME: &'static str = "namespaces";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for Namespace {

--- a/src/v1_13/api/core/v1/node.rs
+++ b/src/v1_13/api/core/v1/node.rs
@@ -1030,7 +1030,10 @@ impl crate::Resource for Node {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Node";
+    const PLURAL_NAME: &'static str = "nodes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for Node {

--- a/src/v1_13/api/core/v1/persistent_volume.rs
+++ b/src/v1_13/api/core/v1/persistent_volume.rs
@@ -550,7 +550,10 @@ impl crate::Resource for PersistentVolume {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PersistentVolume";
+    const PLURAL_NAME: &'static str = "persistentvolumes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PersistentVolume {

--- a/src/v1_13/api/core/v1/persistent_volume_claim.rs
+++ b/src/v1_13/api/core/v1/persistent_volume_claim.rs
@@ -684,7 +684,10 @@ impl crate::Resource for PersistentVolumeClaim {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PersistentVolumeClaim";
+    const PLURAL_NAME: &'static str = "persistentvolumeclaims";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PersistentVolumeClaim {

--- a/src/v1_13/api/core/v1/pod.rs
+++ b/src/v1_13/api/core/v1/pod.rs
@@ -1784,7 +1784,10 @@ impl crate::Resource for Pod {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Pod";
+    const PLURAL_NAME: &'static str = "pods";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Pod {

--- a/src/v1_13/api/core/v1/pod_template.rs
+++ b/src/v1_13/api/core/v1/pod_template.rs
@@ -489,7 +489,10 @@ impl crate::Resource for PodTemplate {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PodTemplate";
+    const PLURAL_NAME: &'static str = "podtemplates";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodTemplate {

--- a/src/v1_13/api/core/v1/replication_controller.rs
+++ b/src/v1_13/api/core/v1/replication_controller.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicationController {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ReplicationController";
+    const PLURAL_NAME: &'static str = "replicationcontrollers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicationController {

--- a/src/v1_13/api/core/v1/resource_quota.rs
+++ b/src/v1_13/api/core/v1/resource_quota.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ResourceQuota {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ResourceQuota";
+    const PLURAL_NAME: &'static str = "resourcequotas";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ResourceQuota {

--- a/src/v1_13/api/core/v1/secret.rs
+++ b/src/v1_13/api/core/v1/secret.rs
@@ -495,7 +495,10 @@ impl crate::Resource for Secret {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Secret";
+    const PLURAL_NAME: &'static str = "secrets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Secret {

--- a/src/v1_13/api/core/v1/service.rs
+++ b/src/v1_13/api/core/v1/service.rs
@@ -1181,7 +1181,10 @@ impl crate::Resource for Service {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Service";
+    const PLURAL_NAME: &'static str = "services";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Service {

--- a/src/v1_13/api/core/v1/service_account.rs
+++ b/src/v1_13/api/core/v1/service_account.rs
@@ -495,7 +495,10 @@ impl crate::Resource for ServiceAccount {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ServiceAccount";
+    const PLURAL_NAME: &'static str = "serviceaccounts";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ServiceAccount {

--- a/src/v1_13/api/events/v1beta1/event.rs
+++ b/src/v1_13/api/events/v1beta1/event.rs
@@ -527,7 +527,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "events.k8s.io/v1beta1";
     const GROUP: &'static str = "events.k8s.io";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_13/api/extensions/v1beta1/daemon_set.rs
+++ b/src/v1_13/api/extensions/v1beta1/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_13/api/extensions/v1beta1/deployment.rs
+++ b/src/v1_13/api/extensions/v1beta1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_13/api/extensions/v1beta1/deployment_rollback.rs
+++ b/src/v1_13/api/extensions/v1beta1/deployment_rollback.rs
@@ -124,7 +124,10 @@ impl crate::Resource for DeploymentRollback {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "DeploymentRollback";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for DeploymentRollback {

--- a/src/v1_13/api/extensions/v1beta1/ingress.rs
+++ b/src/v1_13/api/extensions/v1beta1/ingress.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Ingress {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Ingress";
+    const PLURAL_NAME: &'static str = "ingresses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Ingress {

--- a/src/v1_13/api/extensions/v1beta1/network_policy.rs
+++ b/src/v1_13/api/extensions/v1beta1/network_policy.rs
@@ -489,7 +489,10 @@ impl crate::Resource for NetworkPolicy {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "NetworkPolicy";
+    const PLURAL_NAME: &'static str = "networkpolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for NetworkPolicy {

--- a/src/v1_13/api/extensions/v1beta1/pod_security_policy.rs
+++ b/src/v1_13/api/extensions/v1beta1/pod_security_policy.rs
@@ -373,7 +373,10 @@ impl crate::Resource for PodSecurityPolicy {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "PodSecurityPolicy";
+    const PLURAL_NAME: &'static str = "podsecuritypolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PodSecurityPolicy {

--- a/src/v1_13/api/extensions/v1beta1/replica_set.rs
+++ b/src/v1_13/api/extensions/v1beta1/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_13/api/extensions/v1beta1/scale.rs
+++ b/src/v1_13/api/extensions/v1beta1/scale.rs
@@ -597,7 +597,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_13/api/networking/v1/network_policy.rs
+++ b/src/v1_13/api/networking/v1/network_policy.rs
@@ -489,7 +489,10 @@ impl crate::Resource for NetworkPolicy {
     const API_VERSION: &'static str = "networking.k8s.io/v1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "NetworkPolicy";
+    const PLURAL_NAME: &'static str = "networkpolicies";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for NetworkPolicy {

--- a/src/v1_13/api/policy/v1beta1/eviction.rs
+++ b/src/v1_13/api/policy/v1beta1/eviction.rs
@@ -65,7 +65,10 @@ impl crate::Resource for Eviction {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "Eviction";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Eviction {

--- a/src/v1_13/api/policy/v1beta1/pod_disruption_budget.rs
+++ b/src/v1_13/api/policy/v1beta1/pod_disruption_budget.rs
@@ -683,7 +683,10 @@ impl crate::Resource for PodDisruptionBudget {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "PodDisruptionBudget";
+    const PLURAL_NAME: &'static str = "poddisruptionbudgets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodDisruptionBudget {

--- a/src/v1_13/api/policy/v1beta1/pod_security_policy.rs
+++ b/src/v1_13/api/policy/v1beta1/pod_security_policy.rs
@@ -373,7 +373,10 @@ impl crate::Resource for PodSecurityPolicy {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "PodSecurityPolicy";
+    const PLURAL_NAME: &'static str = "podsecuritypolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PodSecurityPolicy {

--- a/src/v1_13/api/rbac/v1/cluster_role.rs
+++ b/src/v1_13/api/rbac/v1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_13/api/rbac/v1/cluster_role_binding.rs
+++ b/src/v1_13/api/rbac/v1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_13/api/rbac/v1/role.rs
+++ b/src/v1_13/api/rbac/v1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_13/api/rbac/v1/role_binding.rs
+++ b/src/v1_13/api/rbac/v1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_13/api/rbac/v1alpha1/cluster_role.rs
+++ b/src/v1_13/api/rbac/v1alpha1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_13/api/rbac/v1alpha1/cluster_role_binding.rs
+++ b/src/v1_13/api/rbac/v1alpha1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_13/api/rbac/v1alpha1/role.rs
+++ b/src/v1_13/api/rbac/v1alpha1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_13/api/rbac/v1alpha1/role_binding.rs
+++ b/src/v1_13/api/rbac/v1alpha1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_13/api/rbac/v1beta1/cluster_role.rs
+++ b/src/v1_13/api/rbac/v1beta1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_13/api/rbac/v1beta1/cluster_role_binding.rs
+++ b/src/v1_13/api/rbac/v1beta1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_13/api/rbac/v1beta1/role.rs
+++ b/src/v1_13/api/rbac/v1beta1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_13/api/rbac/v1beta1/role_binding.rs
+++ b/src/v1_13/api/rbac/v1beta1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_13/api/scheduling/v1alpha1/priority_class.rs
+++ b/src/v1_13/api/scheduling/v1alpha1/priority_class.rs
@@ -379,7 +379,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1alpha1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_13/api/scheduling/v1beta1/priority_class.rs
+++ b/src/v1_13/api/scheduling/v1beta1/priority_class.rs
@@ -379,7 +379,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1beta1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_13/api/settings/v1alpha1/pod_preset.rs
+++ b/src/v1_13/api/settings/v1alpha1/pod_preset.rs
@@ -487,7 +487,10 @@ impl crate::Resource for PodPreset {
     const API_VERSION: &'static str = "settings.k8s.io/v1alpha1";
     const GROUP: &'static str = "settings.k8s.io";
     const KIND: &'static str = "PodPreset";
+    const PLURAL_NAME: &'static str = "podpresets";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodPreset {

--- a/src/v1_13/api/storage/v1/storage_class.rs
+++ b/src/v1_13/api/storage/v1/storage_class.rs
@@ -393,7 +393,10 @@ impl crate::Resource for StorageClass {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "StorageClass";
+    const PLURAL_NAME: &'static str = "storageclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageClass {

--- a/src/v1_13/api/storage/v1/volume_attachment.rs
+++ b/src/v1_13/api/storage/v1/volume_attachment.rs
@@ -552,7 +552,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_13/api/storage/v1alpha1/volume_attachment.rs
+++ b/src/v1_13/api/storage/v1alpha1/volume_attachment.rs
@@ -378,7 +378,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1alpha1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_13/api/storage/v1beta1/storage_class.rs
+++ b/src/v1_13/api/storage/v1beta1/storage_class.rs
@@ -393,7 +393,10 @@ impl crate::Resource for StorageClass {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "StorageClass";
+    const PLURAL_NAME: &'static str = "storageclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageClass {

--- a/src/v1_13/api/storage/v1beta1/volume_attachment.rs
+++ b/src/v1_13/api/storage/v1beta1/volume_attachment.rs
@@ -378,7 +378,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_13/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
+++ b/src/v1_13/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
@@ -549,7 +549,10 @@ impl crate::Resource for CustomResourceDefinition {
     const API_VERSION: &'static str = "apiextensions.k8s.io/v1beta1";
     const GROUP: &'static str = "apiextensions.k8s.io";
     const KIND: &'static str = "CustomResourceDefinition";
+    const PLURAL_NAME: &'static str = "customresourcedefinitions";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CustomResourceDefinition {

--- a/src/v1_13/apimachinery/pkg/apis/meta/v1/api_group.rs
+++ b/src/v1_13/apimachinery/pkg/apis/meta/v1/api_group.rs
@@ -20,7 +20,10 @@ impl crate::Resource for APIGroup {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIGroup";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIGroup {

--- a/src/v1_13/apimachinery/pkg/apis/meta/v1/api_group_list.rs
+++ b/src/v1_13/apimachinery/pkg/apis/meta/v1/api_group_list.rs
@@ -11,7 +11,10 @@ impl crate::Resource for APIGroupList {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIGroupList";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIGroupList {

--- a/src/v1_13/apimachinery/pkg/apis/meta/v1/api_resource_list.rs
+++ b/src/v1_13/apimachinery/pkg/apis/meta/v1/api_resource_list.rs
@@ -14,7 +14,10 @@ impl crate::Resource for APIResourceList {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIResourceList";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIResourceList {

--- a/src/v1_13/apimachinery/pkg/apis/meta/v1/api_versions.rs
+++ b/src/v1_13/apimachinery/pkg/apis/meta/v1/api_versions.rs
@@ -14,7 +14,10 @@ impl crate::Resource for APIVersions {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIVersions";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIVersions {

--- a/src/v1_13/apimachinery/pkg/apis/meta/v1/status.rs
+++ b/src/v1_13/apimachinery/pkg/apis/meta/v1/status.rs
@@ -26,7 +26,10 @@ impl crate::Resource for Status {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Status";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Status {

--- a/src/v1_13/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
+++ b/src/v1_13/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
@@ -549,7 +549,10 @@ impl crate::Resource for APIService {
     const API_VERSION: &'static str = "apiregistration.k8s.io/v1";
     const GROUP: &'static str = "apiregistration.k8s.io";
     const KIND: &'static str = "APIService";
+    const PLURAL_NAME: &'static str = "apiservices";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for APIService {

--- a/src/v1_13/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
+++ b/src/v1_13/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
@@ -549,7 +549,10 @@ impl crate::Resource for APIService {
     const API_VERSION: &'static str = "apiregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "apiregistration.k8s.io";
     const KIND: &'static str = "APIService";
+    const PLURAL_NAME: &'static str = "apiservices";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for APIService {

--- a/src/v1_13/list.rs
+++ b/src/v1_13/list.rs
@@ -14,7 +14,10 @@ impl<T> crate::Resource for List<T> where T: crate::ListableResource {
     const API_VERSION: &'static str = <T as crate::Resource>::API_VERSION;
     const GROUP: &'static str = <T as crate::Resource>::GROUP;
     const KIND: &'static str = <T as crate::ListableResource>::LIST_KIND;
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = <T as crate::Resource>::VERSION;
+    const NAMESPACED: bool = <T as crate::Resource>::NAMESPACED;
+    type Scope = <T as crate::Resource>::Scope;
 }
 
 impl<T> crate::Metadata for List<T> where T: crate::ListableResource {

--- a/src/v1_14/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
+++ b/src/v1_14/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for MutatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "MutatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "mutatingwebhookconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for MutatingWebhookConfiguration {

--- a/src/v1_14/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
+++ b/src/v1_14/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for ValidatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "ValidatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "validatingwebhookconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ValidatingWebhookConfiguration {

--- a/src/v1_14/api/apps/v1/controller_revision.rs
+++ b/src/v1_14/api/apps/v1/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_14/api/apps/v1/daemon_set.rs
+++ b/src/v1_14/api/apps/v1/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_14/api/apps/v1/deployment.rs
+++ b/src/v1_14/api/apps/v1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_14/api/apps/v1/replica_set.rs
+++ b/src/v1_14/api/apps/v1/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_14/api/apps/v1/stateful_set.rs
+++ b/src/v1_14/api/apps/v1/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_14/api/apps/v1beta1/controller_revision.rs
+++ b/src/v1_14/api/apps/v1beta1/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_14/api/apps/v1beta1/deployment.rs
+++ b/src/v1_14/api/apps/v1beta1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_14/api/apps/v1beta1/deployment_rollback.rs
+++ b/src/v1_14/api/apps/v1beta1/deployment_rollback.rs
@@ -124,7 +124,10 @@ impl crate::Resource for DeploymentRollback {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DeploymentRollback";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for DeploymentRollback {

--- a/src/v1_14/api/apps/v1beta1/scale.rs
+++ b/src/v1_14/api/apps/v1beta1/scale.rs
@@ -405,7 +405,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_14/api/apps/v1beta1/stateful_set.rs
+++ b/src/v1_14/api/apps/v1beta1/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_14/api/apps/v1beta2/controller_revision.rs
+++ b/src/v1_14/api/apps/v1beta2/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_14/api/apps/v1beta2/daemon_set.rs
+++ b/src/v1_14/api/apps/v1beta2/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_14/api/apps/v1beta2/deployment.rs
+++ b/src/v1_14/api/apps/v1beta2/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_14/api/apps/v1beta2/replica_set.rs
+++ b/src/v1_14/api/apps/v1beta2/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_14/api/apps/v1beta2/scale.rs
+++ b/src/v1_14/api/apps/v1beta2/scale.rs
@@ -597,7 +597,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_14/api/apps/v1beta2/stateful_set.rs
+++ b/src/v1_14/api/apps/v1beta2/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_14/api/auditregistration/v1alpha1/audit_sink.rs
+++ b/src/v1_14/api/auditregistration/v1alpha1/audit_sink.rs
@@ -372,7 +372,10 @@ impl crate::Resource for AuditSink {
     const API_VERSION: &'static str = "auditregistration.k8s.io/v1alpha1";
     const GROUP: &'static str = "auditregistration.k8s.io";
     const KIND: &'static str = "AuditSink";
+    const PLURAL_NAME: &'static str = "auditsinks";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for AuditSink {

--- a/src/v1_14/api/authentication/v1/token_review.rs
+++ b/src/v1_14/api/authentication/v1/token_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for TokenReview {
     const API_VERSION: &'static str = "authentication.k8s.io/v1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenReview";
+    const PLURAL_NAME: &'static str = "tokenreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenReview {

--- a/src/v1_14/api/authentication/v1beta1/token_review.rs
+++ b/src/v1_14/api/authentication/v1beta1/token_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for TokenReview {
     const API_VERSION: &'static str = "authentication.k8s.io/v1beta1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenReview";
+    const PLURAL_NAME: &'static str = "tokenreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenReview {

--- a/src/v1_14/api/authorization/v1/local_subject_access_review.rs
+++ b/src/v1_14/api/authorization/v1/local_subject_access_review.rs
@@ -61,7 +61,10 @@ impl crate::Resource for LocalSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "LocalSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "localsubjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for LocalSubjectAccessReview {

--- a/src/v1_14/api/authorization/v1/self_subject_access_review.rs
+++ b/src/v1_14/api/authorization/v1/self_subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "selfsubjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectAccessReview {

--- a/src/v1_14/api/authorization/v1/self_subject_rules_review.rs
+++ b/src/v1_14/api/authorization/v1/self_subject_rules_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectRulesReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectRulesReview";
+    const PLURAL_NAME: &'static str = "selfsubjectrulesreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectRulesReview {

--- a/src/v1_14/api/authorization/v1/subject_access_review.rs
+++ b/src/v1_14/api/authorization/v1/subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SubjectAccessReview";
+    const PLURAL_NAME: &'static str = "subjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SubjectAccessReview {

--- a/src/v1_14/api/authorization/v1beta1/local_subject_access_review.rs
+++ b/src/v1_14/api/authorization/v1beta1/local_subject_access_review.rs
@@ -61,7 +61,10 @@ impl crate::Resource for LocalSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "LocalSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "localsubjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for LocalSubjectAccessReview {

--- a/src/v1_14/api/authorization/v1beta1/self_subject_access_review.rs
+++ b/src/v1_14/api/authorization/v1beta1/self_subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "selfsubjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectAccessReview {

--- a/src/v1_14/api/authorization/v1beta1/self_subject_rules_review.rs
+++ b/src/v1_14/api/authorization/v1beta1/self_subject_rules_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectRulesReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectRulesReview";
+    const PLURAL_NAME: &'static str = "selfsubjectrulesreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectRulesReview {

--- a/src/v1_14/api/authorization/v1beta1/subject_access_review.rs
+++ b/src/v1_14/api/authorization/v1beta1/subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SubjectAccessReview";
+    const PLURAL_NAME: &'static str = "subjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SubjectAccessReview {

--- a/src/v1_14/api/autoscaling/v1/horizontal_pod_autoscaler.rs
+++ b/src/v1_14/api/autoscaling/v1/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_14/api/autoscaling/v1/scale.rs
+++ b/src/v1_14/api/autoscaling/v1/scale.rs
@@ -789,7 +789,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "autoscaling/v1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_14/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
+++ b/src/v1_14/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v2beta1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v2beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_14/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
+++ b/src/v1_14/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v2beta2";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v2beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_14/api/batch/v1/job.rs
+++ b/src/v1_14/api/batch/v1/job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Job {
     const API_VERSION: &'static str = "batch/v1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "Job";
+    const PLURAL_NAME: &'static str = "jobs";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Job {

--- a/src/v1_14/api/batch/v1beta1/cron_job.rs
+++ b/src/v1_14/api/batch/v1beta1/cron_job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for CronJob {
     const API_VERSION: &'static str = "batch/v1beta1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "CronJob";
+    const PLURAL_NAME: &'static str = "cronjobs";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CronJob {

--- a/src/v1_14/api/batch/v2alpha1/cron_job.rs
+++ b/src/v1_14/api/batch/v2alpha1/cron_job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for CronJob {
     const API_VERSION: &'static str = "batch/v2alpha1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "CronJob";
+    const PLURAL_NAME: &'static str = "cronjobs";
     const VERSION: &'static str = "v2alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CronJob {

--- a/src/v1_14/api/certificates/v1beta1/certificate_signing_request.rs
+++ b/src/v1_14/api/certificates/v1beta1/certificate_signing_request.rs
@@ -590,7 +590,10 @@ impl crate::Resource for CertificateSigningRequest {
     const API_VERSION: &'static str = "certificates.k8s.io/v1beta1";
     const GROUP: &'static str = "certificates.k8s.io";
     const KIND: &'static str = "CertificateSigningRequest";
+    const PLURAL_NAME: &'static str = "certificatesigningrequests";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CertificateSigningRequest {

--- a/src/v1_14/api/coordination/v1/lease.rs
+++ b/src/v1_14/api/coordination/v1/lease.rs
@@ -489,7 +489,10 @@ impl crate::Resource for Lease {
     const API_VERSION: &'static str = "coordination.k8s.io/v1";
     const GROUP: &'static str = "coordination.k8s.io";
     const KIND: &'static str = "Lease";
+    const PLURAL_NAME: &'static str = "leases";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Lease {

--- a/src/v1_14/api/coordination/v1beta1/lease.rs
+++ b/src/v1_14/api/coordination/v1beta1/lease.rs
@@ -489,7 +489,10 @@ impl crate::Resource for Lease {
     const API_VERSION: &'static str = "coordination.k8s.io/v1beta1";
     const GROUP: &'static str = "coordination.k8s.io";
     const KIND: &'static str = "Lease";
+    const PLURAL_NAME: &'static str = "leases";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Lease {

--- a/src/v1_14/api/core/v1/binding.rs
+++ b/src/v1_14/api/core/v1/binding.rs
@@ -106,7 +106,10 @@ impl crate::Resource for Binding {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Binding";
+    const PLURAL_NAME: &'static str = "bindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for Binding {

--- a/src/v1_14/api/core/v1/component_status.rs
+++ b/src/v1_14/api/core/v1/component_status.rs
@@ -170,7 +170,10 @@ impl crate::Resource for ComponentStatus {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ComponentStatus";
+    const PLURAL_NAME: &'static str = "componentstatuses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ComponentStatus {

--- a/src/v1_14/api/core/v1/config_map.rs
+++ b/src/v1_14/api/core/v1/config_map.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ConfigMap {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ConfigMap";
+    const PLURAL_NAME: &'static str = "configmaps";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ConfigMap {

--- a/src/v1_14/api/core/v1/endpoints.rs
+++ b/src/v1_14/api/core/v1/endpoints.rs
@@ -500,7 +500,10 @@ impl crate::Resource for Endpoints {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Endpoints";
+    const PLURAL_NAME: &'static str = "endpoints";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Endpoints {

--- a/src/v1_14/api/core/v1/event.rs
+++ b/src/v1_14/api/core/v1/event.rs
@@ -528,7 +528,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_14/api/core/v1/limit_range.rs
+++ b/src/v1_14/api/core/v1/limit_range.rs
@@ -489,7 +489,10 @@ impl crate::Resource for LimitRange {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "LimitRange";
+    const PLURAL_NAME: &'static str = "limitranges";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for LimitRange {

--- a/src/v1_14/api/core/v1/namespace.rs
+++ b/src/v1_14/api/core/v1/namespace.rs
@@ -555,7 +555,10 @@ impl crate::Resource for Namespace {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Namespace";
+    const PLURAL_NAME: &'static str = "namespaces";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for Namespace {

--- a/src/v1_14/api/core/v1/node.rs
+++ b/src/v1_14/api/core/v1/node.rs
@@ -1030,7 +1030,10 @@ impl crate::Resource for Node {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Node";
+    const PLURAL_NAME: &'static str = "nodes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for Node {

--- a/src/v1_14/api/core/v1/persistent_volume.rs
+++ b/src/v1_14/api/core/v1/persistent_volume.rs
@@ -550,7 +550,10 @@ impl crate::Resource for PersistentVolume {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PersistentVolume";
+    const PLURAL_NAME: &'static str = "persistentvolumes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PersistentVolume {

--- a/src/v1_14/api/core/v1/persistent_volume_claim.rs
+++ b/src/v1_14/api/core/v1/persistent_volume_claim.rs
@@ -684,7 +684,10 @@ impl crate::Resource for PersistentVolumeClaim {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PersistentVolumeClaim";
+    const PLURAL_NAME: &'static str = "persistentvolumeclaims";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PersistentVolumeClaim {

--- a/src/v1_14/api/core/v1/pod.rs
+++ b/src/v1_14/api/core/v1/pod.rs
@@ -1784,7 +1784,10 @@ impl crate::Resource for Pod {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Pod";
+    const PLURAL_NAME: &'static str = "pods";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Pod {

--- a/src/v1_14/api/core/v1/pod_template.rs
+++ b/src/v1_14/api/core/v1/pod_template.rs
@@ -489,7 +489,10 @@ impl crate::Resource for PodTemplate {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PodTemplate";
+    const PLURAL_NAME: &'static str = "podtemplates";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodTemplate {

--- a/src/v1_14/api/core/v1/replication_controller.rs
+++ b/src/v1_14/api/core/v1/replication_controller.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicationController {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ReplicationController";
+    const PLURAL_NAME: &'static str = "replicationcontrollers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicationController {

--- a/src/v1_14/api/core/v1/resource_quota.rs
+++ b/src/v1_14/api/core/v1/resource_quota.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ResourceQuota {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ResourceQuota";
+    const PLURAL_NAME: &'static str = "resourcequotas";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ResourceQuota {

--- a/src/v1_14/api/core/v1/secret.rs
+++ b/src/v1_14/api/core/v1/secret.rs
@@ -495,7 +495,10 @@ impl crate::Resource for Secret {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Secret";
+    const PLURAL_NAME: &'static str = "secrets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Secret {

--- a/src/v1_14/api/core/v1/service.rs
+++ b/src/v1_14/api/core/v1/service.rs
@@ -1181,7 +1181,10 @@ impl crate::Resource for Service {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Service";
+    const PLURAL_NAME: &'static str = "services";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Service {

--- a/src/v1_14/api/core/v1/service_account.rs
+++ b/src/v1_14/api/core/v1/service_account.rs
@@ -495,7 +495,10 @@ impl crate::Resource for ServiceAccount {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ServiceAccount";
+    const PLURAL_NAME: &'static str = "serviceaccounts";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ServiceAccount {

--- a/src/v1_14/api/events/v1beta1/event.rs
+++ b/src/v1_14/api/events/v1beta1/event.rs
@@ -527,7 +527,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "events.k8s.io/v1beta1";
     const GROUP: &'static str = "events.k8s.io";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_14/api/extensions/v1beta1/daemon_set.rs
+++ b/src/v1_14/api/extensions/v1beta1/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_14/api/extensions/v1beta1/deployment.rs
+++ b/src/v1_14/api/extensions/v1beta1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_14/api/extensions/v1beta1/deployment_rollback.rs
+++ b/src/v1_14/api/extensions/v1beta1/deployment_rollback.rs
@@ -124,7 +124,10 @@ impl crate::Resource for DeploymentRollback {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "DeploymentRollback";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for DeploymentRollback {

--- a/src/v1_14/api/extensions/v1beta1/ingress.rs
+++ b/src/v1_14/api/extensions/v1beta1/ingress.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Ingress {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Ingress";
+    const PLURAL_NAME: &'static str = "ingresses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Ingress {

--- a/src/v1_14/api/extensions/v1beta1/network_policy.rs
+++ b/src/v1_14/api/extensions/v1beta1/network_policy.rs
@@ -489,7 +489,10 @@ impl crate::Resource for NetworkPolicy {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "NetworkPolicy";
+    const PLURAL_NAME: &'static str = "networkpolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for NetworkPolicy {

--- a/src/v1_14/api/extensions/v1beta1/pod_security_policy.rs
+++ b/src/v1_14/api/extensions/v1beta1/pod_security_policy.rs
@@ -373,7 +373,10 @@ impl crate::Resource for PodSecurityPolicy {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "PodSecurityPolicy";
+    const PLURAL_NAME: &'static str = "podsecuritypolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PodSecurityPolicy {

--- a/src/v1_14/api/extensions/v1beta1/replica_set.rs
+++ b/src/v1_14/api/extensions/v1beta1/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_14/api/extensions/v1beta1/scale.rs
+++ b/src/v1_14/api/extensions/v1beta1/scale.rs
@@ -597,7 +597,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_14/api/networking/v1/network_policy.rs
+++ b/src/v1_14/api/networking/v1/network_policy.rs
@@ -489,7 +489,10 @@ impl crate::Resource for NetworkPolicy {
     const API_VERSION: &'static str = "networking.k8s.io/v1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "NetworkPolicy";
+    const PLURAL_NAME: &'static str = "networkpolicies";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for NetworkPolicy {

--- a/src/v1_14/api/networking/v1beta1/ingress.rs
+++ b/src/v1_14/api/networking/v1beta1/ingress.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Ingress {
     const API_VERSION: &'static str = "networking.k8s.io/v1beta1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "Ingress";
+    const PLURAL_NAME: &'static str = "ingresses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Ingress {

--- a/src/v1_14/api/node/v1alpha1/runtime_class.rs
+++ b/src/v1_14/api/node/v1alpha1/runtime_class.rs
@@ -373,7 +373,10 @@ impl crate::Resource for RuntimeClass {
     const API_VERSION: &'static str = "node.k8s.io/v1alpha1";
     const GROUP: &'static str = "node.k8s.io";
     const KIND: &'static str = "RuntimeClass";
+    const PLURAL_NAME: &'static str = "runtimeclasses";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for RuntimeClass {

--- a/src/v1_14/api/node/v1beta1/runtime_class.rs
+++ b/src/v1_14/api/node/v1beta1/runtime_class.rs
@@ -373,7 +373,10 @@ impl crate::Resource for RuntimeClass {
     const API_VERSION: &'static str = "node.k8s.io/v1beta1";
     const GROUP: &'static str = "node.k8s.io";
     const KIND: &'static str = "RuntimeClass";
+    const PLURAL_NAME: &'static str = "runtimeclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for RuntimeClass {

--- a/src/v1_14/api/policy/v1beta1/eviction.rs
+++ b/src/v1_14/api/policy/v1beta1/eviction.rs
@@ -65,7 +65,10 @@ impl crate::Resource for Eviction {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "Eviction";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Eviction {

--- a/src/v1_14/api/policy/v1beta1/pod_disruption_budget.rs
+++ b/src/v1_14/api/policy/v1beta1/pod_disruption_budget.rs
@@ -683,7 +683,10 @@ impl crate::Resource for PodDisruptionBudget {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "PodDisruptionBudget";
+    const PLURAL_NAME: &'static str = "poddisruptionbudgets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodDisruptionBudget {

--- a/src/v1_14/api/policy/v1beta1/pod_security_policy.rs
+++ b/src/v1_14/api/policy/v1beta1/pod_security_policy.rs
@@ -373,7 +373,10 @@ impl crate::Resource for PodSecurityPolicy {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "PodSecurityPolicy";
+    const PLURAL_NAME: &'static str = "podsecuritypolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PodSecurityPolicy {

--- a/src/v1_14/api/rbac/v1/cluster_role.rs
+++ b/src/v1_14/api/rbac/v1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_14/api/rbac/v1/cluster_role_binding.rs
+++ b/src/v1_14/api/rbac/v1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_14/api/rbac/v1/role.rs
+++ b/src/v1_14/api/rbac/v1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_14/api/rbac/v1/role_binding.rs
+++ b/src/v1_14/api/rbac/v1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_14/api/rbac/v1alpha1/cluster_role.rs
+++ b/src/v1_14/api/rbac/v1alpha1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_14/api/rbac/v1alpha1/cluster_role_binding.rs
+++ b/src/v1_14/api/rbac/v1alpha1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_14/api/rbac/v1alpha1/role.rs
+++ b/src/v1_14/api/rbac/v1alpha1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_14/api/rbac/v1alpha1/role_binding.rs
+++ b/src/v1_14/api/rbac/v1alpha1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_14/api/rbac/v1beta1/cluster_role.rs
+++ b/src/v1_14/api/rbac/v1beta1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_14/api/rbac/v1beta1/cluster_role_binding.rs
+++ b/src/v1_14/api/rbac/v1beta1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_14/api/rbac/v1beta1/role.rs
+++ b/src/v1_14/api/rbac/v1beta1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_14/api/rbac/v1beta1/role_binding.rs
+++ b/src/v1_14/api/rbac/v1beta1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_14/api/scheduling/v1/priority_class.rs
+++ b/src/v1_14/api/scheduling/v1/priority_class.rs
@@ -379,7 +379,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_14/api/scheduling/v1alpha1/priority_class.rs
+++ b/src/v1_14/api/scheduling/v1alpha1/priority_class.rs
@@ -379,7 +379,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1alpha1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_14/api/scheduling/v1beta1/priority_class.rs
+++ b/src/v1_14/api/scheduling/v1beta1/priority_class.rs
@@ -379,7 +379,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1beta1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_14/api/settings/v1alpha1/pod_preset.rs
+++ b/src/v1_14/api/settings/v1alpha1/pod_preset.rs
@@ -487,7 +487,10 @@ impl crate::Resource for PodPreset {
     const API_VERSION: &'static str = "settings.k8s.io/v1alpha1";
     const GROUP: &'static str = "settings.k8s.io";
     const KIND: &'static str = "PodPreset";
+    const PLURAL_NAME: &'static str = "podpresets";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodPreset {

--- a/src/v1_14/api/storage/v1/storage_class.rs
+++ b/src/v1_14/api/storage/v1/storage_class.rs
@@ -393,7 +393,10 @@ impl crate::Resource for StorageClass {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "StorageClass";
+    const PLURAL_NAME: &'static str = "storageclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageClass {

--- a/src/v1_14/api/storage/v1/volume_attachment.rs
+++ b/src/v1_14/api/storage/v1/volume_attachment.rs
@@ -552,7 +552,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_14/api/storage/v1alpha1/volume_attachment.rs
+++ b/src/v1_14/api/storage/v1alpha1/volume_attachment.rs
@@ -378,7 +378,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1alpha1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_14/api/storage/v1beta1/csi_driver.rs
+++ b/src/v1_14/api/storage/v1beta1/csi_driver.rs
@@ -373,7 +373,10 @@ impl crate::Resource for CSIDriver {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSIDriver";
+    const PLURAL_NAME: &'static str = "csidrivers";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSIDriver {

--- a/src/v1_14/api/storage/v1beta1/csi_node.rs
+++ b/src/v1_14/api/storage/v1beta1/csi_node.rs
@@ -373,7 +373,10 @@ impl crate::Resource for CSINode {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSINode";
+    const PLURAL_NAME: &'static str = "csinodes";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSINode {

--- a/src/v1_14/api/storage/v1beta1/storage_class.rs
+++ b/src/v1_14/api/storage/v1beta1/storage_class.rs
@@ -393,7 +393,10 @@ impl crate::Resource for StorageClass {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "StorageClass";
+    const PLURAL_NAME: &'static str = "storageclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageClass {

--- a/src/v1_14/api/storage/v1beta1/volume_attachment.rs
+++ b/src/v1_14/api/storage/v1beta1/volume_attachment.rs
@@ -378,7 +378,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_14/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
+++ b/src/v1_14/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
@@ -549,7 +549,10 @@ impl crate::Resource for CustomResourceDefinition {
     const API_VERSION: &'static str = "apiextensions.k8s.io/v1beta1";
     const GROUP: &'static str = "apiextensions.k8s.io";
     const KIND: &'static str = "CustomResourceDefinition";
+    const PLURAL_NAME: &'static str = "customresourcedefinitions";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CustomResourceDefinition {

--- a/src/v1_14/apimachinery/pkg/apis/meta/v1/api_group.rs
+++ b/src/v1_14/apimachinery/pkg/apis/meta/v1/api_group.rs
@@ -20,7 +20,10 @@ impl crate::Resource for APIGroup {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIGroup";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIGroup {

--- a/src/v1_14/apimachinery/pkg/apis/meta/v1/api_group_list.rs
+++ b/src/v1_14/apimachinery/pkg/apis/meta/v1/api_group_list.rs
@@ -11,7 +11,10 @@ impl crate::Resource for APIGroupList {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIGroupList";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIGroupList {

--- a/src/v1_14/apimachinery/pkg/apis/meta/v1/api_resource_list.rs
+++ b/src/v1_14/apimachinery/pkg/apis/meta/v1/api_resource_list.rs
@@ -14,7 +14,10 @@ impl crate::Resource for APIResourceList {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIResourceList";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIResourceList {

--- a/src/v1_14/apimachinery/pkg/apis/meta/v1/api_versions.rs
+++ b/src/v1_14/apimachinery/pkg/apis/meta/v1/api_versions.rs
@@ -14,7 +14,10 @@ impl crate::Resource for APIVersions {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIVersions";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIVersions {

--- a/src/v1_14/apimachinery/pkg/apis/meta/v1/status.rs
+++ b/src/v1_14/apimachinery/pkg/apis/meta/v1/status.rs
@@ -26,7 +26,10 @@ impl crate::Resource for Status {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Status";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Status {

--- a/src/v1_14/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
+++ b/src/v1_14/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
@@ -549,7 +549,10 @@ impl crate::Resource for APIService {
     const API_VERSION: &'static str = "apiregistration.k8s.io/v1";
     const GROUP: &'static str = "apiregistration.k8s.io";
     const KIND: &'static str = "APIService";
+    const PLURAL_NAME: &'static str = "apiservices";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for APIService {

--- a/src/v1_14/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
+++ b/src/v1_14/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
@@ -549,7 +549,10 @@ impl crate::Resource for APIService {
     const API_VERSION: &'static str = "apiregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "apiregistration.k8s.io";
     const KIND: &'static str = "APIService";
+    const PLURAL_NAME: &'static str = "apiservices";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for APIService {

--- a/src/v1_14/list.rs
+++ b/src/v1_14/list.rs
@@ -14,7 +14,10 @@ impl<T> crate::Resource for List<T> where T: crate::ListableResource {
     const API_VERSION: &'static str = <T as crate::Resource>::API_VERSION;
     const GROUP: &'static str = <T as crate::Resource>::GROUP;
     const KIND: &'static str = <T as crate::ListableResource>::LIST_KIND;
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = <T as crate::Resource>::VERSION;
+    const NAMESPACED: bool = <T as crate::Resource>::NAMESPACED;
+    type Scope = <T as crate::Resource>::Scope;
 }
 
 impl<T> crate::Metadata for List<T> where T: crate::ListableResource {

--- a/src/v1_15/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
+++ b/src/v1_15/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for MutatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "MutatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "mutatingwebhookconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for MutatingWebhookConfiguration {

--- a/src/v1_15/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
+++ b/src/v1_15/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for ValidatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "ValidatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "validatingwebhookconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ValidatingWebhookConfiguration {

--- a/src/v1_15/api/apps/v1/controller_revision.rs
+++ b/src/v1_15/api/apps/v1/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_15/api/apps/v1/daemon_set.rs
+++ b/src/v1_15/api/apps/v1/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_15/api/apps/v1/deployment.rs
+++ b/src/v1_15/api/apps/v1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_15/api/apps/v1/replica_set.rs
+++ b/src/v1_15/api/apps/v1/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_15/api/apps/v1/stateful_set.rs
+++ b/src/v1_15/api/apps/v1/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_15/api/apps/v1beta1/controller_revision.rs
+++ b/src/v1_15/api/apps/v1beta1/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_15/api/apps/v1beta1/deployment.rs
+++ b/src/v1_15/api/apps/v1beta1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_15/api/apps/v1beta1/deployment_rollback.rs
+++ b/src/v1_15/api/apps/v1beta1/deployment_rollback.rs
@@ -124,7 +124,10 @@ impl crate::Resource for DeploymentRollback {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DeploymentRollback";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for DeploymentRollback {

--- a/src/v1_15/api/apps/v1beta1/scale.rs
+++ b/src/v1_15/api/apps/v1beta1/scale.rs
@@ -405,7 +405,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_15/api/apps/v1beta1/stateful_set.rs
+++ b/src/v1_15/api/apps/v1beta1/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_15/api/apps/v1beta2/controller_revision.rs
+++ b/src/v1_15/api/apps/v1beta2/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_15/api/apps/v1beta2/daemon_set.rs
+++ b/src/v1_15/api/apps/v1beta2/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_15/api/apps/v1beta2/deployment.rs
+++ b/src/v1_15/api/apps/v1beta2/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_15/api/apps/v1beta2/replica_set.rs
+++ b/src/v1_15/api/apps/v1beta2/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_15/api/apps/v1beta2/scale.rs
+++ b/src/v1_15/api/apps/v1beta2/scale.rs
@@ -597,7 +597,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_15/api/apps/v1beta2/stateful_set.rs
+++ b/src/v1_15/api/apps/v1beta2/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_15/api/auditregistration/v1alpha1/audit_sink.rs
+++ b/src/v1_15/api/auditregistration/v1alpha1/audit_sink.rs
@@ -372,7 +372,10 @@ impl crate::Resource for AuditSink {
     const API_VERSION: &'static str = "auditregistration.k8s.io/v1alpha1";
     const GROUP: &'static str = "auditregistration.k8s.io";
     const KIND: &'static str = "AuditSink";
+    const PLURAL_NAME: &'static str = "auditsinks";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for AuditSink {

--- a/src/v1_15/api/authentication/v1/token_review.rs
+++ b/src/v1_15/api/authentication/v1/token_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for TokenReview {
     const API_VERSION: &'static str = "authentication.k8s.io/v1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenReview";
+    const PLURAL_NAME: &'static str = "tokenreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenReview {

--- a/src/v1_15/api/authentication/v1beta1/token_review.rs
+++ b/src/v1_15/api/authentication/v1beta1/token_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for TokenReview {
     const API_VERSION: &'static str = "authentication.k8s.io/v1beta1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenReview";
+    const PLURAL_NAME: &'static str = "tokenreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenReview {

--- a/src/v1_15/api/authorization/v1/local_subject_access_review.rs
+++ b/src/v1_15/api/authorization/v1/local_subject_access_review.rs
@@ -61,7 +61,10 @@ impl crate::Resource for LocalSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "LocalSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "localsubjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for LocalSubjectAccessReview {

--- a/src/v1_15/api/authorization/v1/self_subject_access_review.rs
+++ b/src/v1_15/api/authorization/v1/self_subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "selfsubjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectAccessReview {

--- a/src/v1_15/api/authorization/v1/self_subject_rules_review.rs
+++ b/src/v1_15/api/authorization/v1/self_subject_rules_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectRulesReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectRulesReview";
+    const PLURAL_NAME: &'static str = "selfsubjectrulesreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectRulesReview {

--- a/src/v1_15/api/authorization/v1/subject_access_review.rs
+++ b/src/v1_15/api/authorization/v1/subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SubjectAccessReview";
+    const PLURAL_NAME: &'static str = "subjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SubjectAccessReview {

--- a/src/v1_15/api/authorization/v1beta1/local_subject_access_review.rs
+++ b/src/v1_15/api/authorization/v1beta1/local_subject_access_review.rs
@@ -61,7 +61,10 @@ impl crate::Resource for LocalSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "LocalSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "localsubjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for LocalSubjectAccessReview {

--- a/src/v1_15/api/authorization/v1beta1/self_subject_access_review.rs
+++ b/src/v1_15/api/authorization/v1beta1/self_subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "selfsubjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectAccessReview {

--- a/src/v1_15/api/authorization/v1beta1/self_subject_rules_review.rs
+++ b/src/v1_15/api/authorization/v1beta1/self_subject_rules_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectRulesReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectRulesReview";
+    const PLURAL_NAME: &'static str = "selfsubjectrulesreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectRulesReview {

--- a/src/v1_15/api/authorization/v1beta1/subject_access_review.rs
+++ b/src/v1_15/api/authorization/v1beta1/subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SubjectAccessReview";
+    const PLURAL_NAME: &'static str = "subjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SubjectAccessReview {

--- a/src/v1_15/api/autoscaling/v1/horizontal_pod_autoscaler.rs
+++ b/src/v1_15/api/autoscaling/v1/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_15/api/autoscaling/v1/scale.rs
+++ b/src/v1_15/api/autoscaling/v1/scale.rs
@@ -789,7 +789,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "autoscaling/v1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_15/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
+++ b/src/v1_15/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v2beta1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v2beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_15/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
+++ b/src/v1_15/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v2beta2";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v2beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_15/api/batch/v1/job.rs
+++ b/src/v1_15/api/batch/v1/job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Job {
     const API_VERSION: &'static str = "batch/v1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "Job";
+    const PLURAL_NAME: &'static str = "jobs";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Job {

--- a/src/v1_15/api/batch/v1beta1/cron_job.rs
+++ b/src/v1_15/api/batch/v1beta1/cron_job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for CronJob {
     const API_VERSION: &'static str = "batch/v1beta1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "CronJob";
+    const PLURAL_NAME: &'static str = "cronjobs";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CronJob {

--- a/src/v1_15/api/batch/v2alpha1/cron_job.rs
+++ b/src/v1_15/api/batch/v2alpha1/cron_job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for CronJob {
     const API_VERSION: &'static str = "batch/v2alpha1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "CronJob";
+    const PLURAL_NAME: &'static str = "cronjobs";
     const VERSION: &'static str = "v2alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CronJob {

--- a/src/v1_15/api/certificates/v1beta1/certificate_signing_request.rs
+++ b/src/v1_15/api/certificates/v1beta1/certificate_signing_request.rs
@@ -590,7 +590,10 @@ impl crate::Resource for CertificateSigningRequest {
     const API_VERSION: &'static str = "certificates.k8s.io/v1beta1";
     const GROUP: &'static str = "certificates.k8s.io";
     const KIND: &'static str = "CertificateSigningRequest";
+    const PLURAL_NAME: &'static str = "certificatesigningrequests";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CertificateSigningRequest {

--- a/src/v1_15/api/coordination/v1/lease.rs
+++ b/src/v1_15/api/coordination/v1/lease.rs
@@ -489,7 +489,10 @@ impl crate::Resource for Lease {
     const API_VERSION: &'static str = "coordination.k8s.io/v1";
     const GROUP: &'static str = "coordination.k8s.io";
     const KIND: &'static str = "Lease";
+    const PLURAL_NAME: &'static str = "leases";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Lease {

--- a/src/v1_15/api/coordination/v1beta1/lease.rs
+++ b/src/v1_15/api/coordination/v1beta1/lease.rs
@@ -489,7 +489,10 @@ impl crate::Resource for Lease {
     const API_VERSION: &'static str = "coordination.k8s.io/v1beta1";
     const GROUP: &'static str = "coordination.k8s.io";
     const KIND: &'static str = "Lease";
+    const PLURAL_NAME: &'static str = "leases";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Lease {

--- a/src/v1_15/api/core/v1/binding.rs
+++ b/src/v1_15/api/core/v1/binding.rs
@@ -106,7 +106,10 @@ impl crate::Resource for Binding {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Binding";
+    const PLURAL_NAME: &'static str = "bindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for Binding {

--- a/src/v1_15/api/core/v1/component_status.rs
+++ b/src/v1_15/api/core/v1/component_status.rs
@@ -170,7 +170,10 @@ impl crate::Resource for ComponentStatus {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ComponentStatus";
+    const PLURAL_NAME: &'static str = "componentstatuses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ComponentStatus {

--- a/src/v1_15/api/core/v1/config_map.rs
+++ b/src/v1_15/api/core/v1/config_map.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ConfigMap {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ConfigMap";
+    const PLURAL_NAME: &'static str = "configmaps";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ConfigMap {

--- a/src/v1_15/api/core/v1/endpoints.rs
+++ b/src/v1_15/api/core/v1/endpoints.rs
@@ -500,7 +500,10 @@ impl crate::Resource for Endpoints {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Endpoints";
+    const PLURAL_NAME: &'static str = "endpoints";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Endpoints {

--- a/src/v1_15/api/core/v1/event.rs
+++ b/src/v1_15/api/core/v1/event.rs
@@ -528,7 +528,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_15/api/core/v1/limit_range.rs
+++ b/src/v1_15/api/core/v1/limit_range.rs
@@ -489,7 +489,10 @@ impl crate::Resource for LimitRange {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "LimitRange";
+    const PLURAL_NAME: &'static str = "limitranges";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for LimitRange {

--- a/src/v1_15/api/core/v1/namespace.rs
+++ b/src/v1_15/api/core/v1/namespace.rs
@@ -555,7 +555,10 @@ impl crate::Resource for Namespace {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Namespace";
+    const PLURAL_NAME: &'static str = "namespaces";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for Namespace {

--- a/src/v1_15/api/core/v1/node.rs
+++ b/src/v1_15/api/core/v1/node.rs
@@ -1030,7 +1030,10 @@ impl crate::Resource for Node {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Node";
+    const PLURAL_NAME: &'static str = "nodes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for Node {

--- a/src/v1_15/api/core/v1/persistent_volume.rs
+++ b/src/v1_15/api/core/v1/persistent_volume.rs
@@ -550,7 +550,10 @@ impl crate::Resource for PersistentVolume {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PersistentVolume";
+    const PLURAL_NAME: &'static str = "persistentvolumes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PersistentVolume {

--- a/src/v1_15/api/core/v1/persistent_volume_claim.rs
+++ b/src/v1_15/api/core/v1/persistent_volume_claim.rs
@@ -684,7 +684,10 @@ impl crate::Resource for PersistentVolumeClaim {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PersistentVolumeClaim";
+    const PLURAL_NAME: &'static str = "persistentvolumeclaims";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PersistentVolumeClaim {

--- a/src/v1_15/api/core/v1/pod.rs
+++ b/src/v1_15/api/core/v1/pod.rs
@@ -1784,7 +1784,10 @@ impl crate::Resource for Pod {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Pod";
+    const PLURAL_NAME: &'static str = "pods";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Pod {

--- a/src/v1_15/api/core/v1/pod_template.rs
+++ b/src/v1_15/api/core/v1/pod_template.rs
@@ -489,7 +489,10 @@ impl crate::Resource for PodTemplate {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PodTemplate";
+    const PLURAL_NAME: &'static str = "podtemplates";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodTemplate {

--- a/src/v1_15/api/core/v1/replication_controller.rs
+++ b/src/v1_15/api/core/v1/replication_controller.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicationController {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ReplicationController";
+    const PLURAL_NAME: &'static str = "replicationcontrollers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicationController {

--- a/src/v1_15/api/core/v1/resource_quota.rs
+++ b/src/v1_15/api/core/v1/resource_quota.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ResourceQuota {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ResourceQuota";
+    const PLURAL_NAME: &'static str = "resourcequotas";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ResourceQuota {

--- a/src/v1_15/api/core/v1/secret.rs
+++ b/src/v1_15/api/core/v1/secret.rs
@@ -495,7 +495,10 @@ impl crate::Resource for Secret {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Secret";
+    const PLURAL_NAME: &'static str = "secrets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Secret {

--- a/src/v1_15/api/core/v1/service.rs
+++ b/src/v1_15/api/core/v1/service.rs
@@ -1181,7 +1181,10 @@ impl crate::Resource for Service {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Service";
+    const PLURAL_NAME: &'static str = "services";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Service {

--- a/src/v1_15/api/core/v1/service_account.rs
+++ b/src/v1_15/api/core/v1/service_account.rs
@@ -495,7 +495,10 @@ impl crate::Resource for ServiceAccount {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ServiceAccount";
+    const PLURAL_NAME: &'static str = "serviceaccounts";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ServiceAccount {

--- a/src/v1_15/api/events/v1beta1/event.rs
+++ b/src/v1_15/api/events/v1beta1/event.rs
@@ -527,7 +527,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "events.k8s.io/v1beta1";
     const GROUP: &'static str = "events.k8s.io";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_15/api/extensions/v1beta1/daemon_set.rs
+++ b/src/v1_15/api/extensions/v1beta1/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_15/api/extensions/v1beta1/deployment.rs
+++ b/src/v1_15/api/extensions/v1beta1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_15/api/extensions/v1beta1/deployment_rollback.rs
+++ b/src/v1_15/api/extensions/v1beta1/deployment_rollback.rs
@@ -124,7 +124,10 @@ impl crate::Resource for DeploymentRollback {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "DeploymentRollback";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for DeploymentRollback {

--- a/src/v1_15/api/extensions/v1beta1/ingress.rs
+++ b/src/v1_15/api/extensions/v1beta1/ingress.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Ingress {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Ingress";
+    const PLURAL_NAME: &'static str = "ingresses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Ingress {

--- a/src/v1_15/api/extensions/v1beta1/network_policy.rs
+++ b/src/v1_15/api/extensions/v1beta1/network_policy.rs
@@ -489,7 +489,10 @@ impl crate::Resource for NetworkPolicy {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "NetworkPolicy";
+    const PLURAL_NAME: &'static str = "networkpolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for NetworkPolicy {

--- a/src/v1_15/api/extensions/v1beta1/pod_security_policy.rs
+++ b/src/v1_15/api/extensions/v1beta1/pod_security_policy.rs
@@ -373,7 +373,10 @@ impl crate::Resource for PodSecurityPolicy {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "PodSecurityPolicy";
+    const PLURAL_NAME: &'static str = "podsecuritypolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PodSecurityPolicy {

--- a/src/v1_15/api/extensions/v1beta1/replica_set.rs
+++ b/src/v1_15/api/extensions/v1beta1/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_15/api/extensions/v1beta1/scale.rs
+++ b/src/v1_15/api/extensions/v1beta1/scale.rs
@@ -597,7 +597,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_15/api/networking/v1/network_policy.rs
+++ b/src/v1_15/api/networking/v1/network_policy.rs
@@ -489,7 +489,10 @@ impl crate::Resource for NetworkPolicy {
     const API_VERSION: &'static str = "networking.k8s.io/v1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "NetworkPolicy";
+    const PLURAL_NAME: &'static str = "networkpolicies";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for NetworkPolicy {

--- a/src/v1_15/api/networking/v1beta1/ingress.rs
+++ b/src/v1_15/api/networking/v1beta1/ingress.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Ingress {
     const API_VERSION: &'static str = "networking.k8s.io/v1beta1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "Ingress";
+    const PLURAL_NAME: &'static str = "ingresses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Ingress {

--- a/src/v1_15/api/node/v1alpha1/runtime_class.rs
+++ b/src/v1_15/api/node/v1alpha1/runtime_class.rs
@@ -373,7 +373,10 @@ impl crate::Resource for RuntimeClass {
     const API_VERSION: &'static str = "node.k8s.io/v1alpha1";
     const GROUP: &'static str = "node.k8s.io";
     const KIND: &'static str = "RuntimeClass";
+    const PLURAL_NAME: &'static str = "runtimeclasses";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for RuntimeClass {

--- a/src/v1_15/api/node/v1beta1/runtime_class.rs
+++ b/src/v1_15/api/node/v1beta1/runtime_class.rs
@@ -373,7 +373,10 @@ impl crate::Resource for RuntimeClass {
     const API_VERSION: &'static str = "node.k8s.io/v1beta1";
     const GROUP: &'static str = "node.k8s.io";
     const KIND: &'static str = "RuntimeClass";
+    const PLURAL_NAME: &'static str = "runtimeclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for RuntimeClass {

--- a/src/v1_15/api/policy/v1beta1/eviction.rs
+++ b/src/v1_15/api/policy/v1beta1/eviction.rs
@@ -65,7 +65,10 @@ impl crate::Resource for Eviction {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "Eviction";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Eviction {

--- a/src/v1_15/api/policy/v1beta1/pod_disruption_budget.rs
+++ b/src/v1_15/api/policy/v1beta1/pod_disruption_budget.rs
@@ -683,7 +683,10 @@ impl crate::Resource for PodDisruptionBudget {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "PodDisruptionBudget";
+    const PLURAL_NAME: &'static str = "poddisruptionbudgets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodDisruptionBudget {

--- a/src/v1_15/api/policy/v1beta1/pod_security_policy.rs
+++ b/src/v1_15/api/policy/v1beta1/pod_security_policy.rs
@@ -373,7 +373,10 @@ impl crate::Resource for PodSecurityPolicy {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "PodSecurityPolicy";
+    const PLURAL_NAME: &'static str = "podsecuritypolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PodSecurityPolicy {

--- a/src/v1_15/api/rbac/v1/cluster_role.rs
+++ b/src/v1_15/api/rbac/v1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_15/api/rbac/v1/cluster_role_binding.rs
+++ b/src/v1_15/api/rbac/v1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_15/api/rbac/v1/role.rs
+++ b/src/v1_15/api/rbac/v1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_15/api/rbac/v1/role_binding.rs
+++ b/src/v1_15/api/rbac/v1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_15/api/rbac/v1alpha1/cluster_role.rs
+++ b/src/v1_15/api/rbac/v1alpha1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_15/api/rbac/v1alpha1/cluster_role_binding.rs
+++ b/src/v1_15/api/rbac/v1alpha1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_15/api/rbac/v1alpha1/role.rs
+++ b/src/v1_15/api/rbac/v1alpha1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_15/api/rbac/v1alpha1/role_binding.rs
+++ b/src/v1_15/api/rbac/v1alpha1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_15/api/rbac/v1beta1/cluster_role.rs
+++ b/src/v1_15/api/rbac/v1beta1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_15/api/rbac/v1beta1/cluster_role_binding.rs
+++ b/src/v1_15/api/rbac/v1beta1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_15/api/rbac/v1beta1/role.rs
+++ b/src/v1_15/api/rbac/v1beta1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_15/api/rbac/v1beta1/role_binding.rs
+++ b/src/v1_15/api/rbac/v1beta1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_15/api/scheduling/v1/priority_class.rs
+++ b/src/v1_15/api/scheduling/v1/priority_class.rs
@@ -382,7 +382,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_15/api/scheduling/v1alpha1/priority_class.rs
+++ b/src/v1_15/api/scheduling/v1alpha1/priority_class.rs
@@ -382,7 +382,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1alpha1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_15/api/scheduling/v1beta1/priority_class.rs
+++ b/src/v1_15/api/scheduling/v1beta1/priority_class.rs
@@ -382,7 +382,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1beta1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_15/api/settings/v1alpha1/pod_preset.rs
+++ b/src/v1_15/api/settings/v1alpha1/pod_preset.rs
@@ -487,7 +487,10 @@ impl crate::Resource for PodPreset {
     const API_VERSION: &'static str = "settings.k8s.io/v1alpha1";
     const GROUP: &'static str = "settings.k8s.io";
     const KIND: &'static str = "PodPreset";
+    const PLURAL_NAME: &'static str = "podpresets";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodPreset {

--- a/src/v1_15/api/storage/v1/storage_class.rs
+++ b/src/v1_15/api/storage/v1/storage_class.rs
@@ -393,7 +393,10 @@ impl crate::Resource for StorageClass {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "StorageClass";
+    const PLURAL_NAME: &'static str = "storageclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageClass {

--- a/src/v1_15/api/storage/v1/volume_attachment.rs
+++ b/src/v1_15/api/storage/v1/volume_attachment.rs
@@ -552,7 +552,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_15/api/storage/v1alpha1/volume_attachment.rs
+++ b/src/v1_15/api/storage/v1alpha1/volume_attachment.rs
@@ -378,7 +378,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1alpha1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_15/api/storage/v1beta1/csi_driver.rs
+++ b/src/v1_15/api/storage/v1beta1/csi_driver.rs
@@ -373,7 +373,10 @@ impl crate::Resource for CSIDriver {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSIDriver";
+    const PLURAL_NAME: &'static str = "csidrivers";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSIDriver {

--- a/src/v1_15/api/storage/v1beta1/csi_node.rs
+++ b/src/v1_15/api/storage/v1beta1/csi_node.rs
@@ -373,7 +373,10 @@ impl crate::Resource for CSINode {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSINode";
+    const PLURAL_NAME: &'static str = "csinodes";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSINode {

--- a/src/v1_15/api/storage/v1beta1/storage_class.rs
+++ b/src/v1_15/api/storage/v1beta1/storage_class.rs
@@ -393,7 +393,10 @@ impl crate::Resource for StorageClass {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "StorageClass";
+    const PLURAL_NAME: &'static str = "storageclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageClass {

--- a/src/v1_15/api/storage/v1beta1/volume_attachment.rs
+++ b/src/v1_15/api/storage/v1beta1/volume_attachment.rs
@@ -378,7 +378,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_15/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
+++ b/src/v1_15/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
@@ -549,7 +549,10 @@ impl crate::Resource for CustomResourceDefinition {
     const API_VERSION: &'static str = "apiextensions.k8s.io/v1beta1";
     const GROUP: &'static str = "apiextensions.k8s.io";
     const KIND: &'static str = "CustomResourceDefinition";
+    const PLURAL_NAME: &'static str = "customresourcedefinitions";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CustomResourceDefinition {

--- a/src/v1_15/apimachinery/pkg/apis/meta/v1/api_group.rs
+++ b/src/v1_15/apimachinery/pkg/apis/meta/v1/api_group.rs
@@ -20,7 +20,10 @@ impl crate::Resource for APIGroup {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIGroup";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIGroup {

--- a/src/v1_15/apimachinery/pkg/apis/meta/v1/api_group_list.rs
+++ b/src/v1_15/apimachinery/pkg/apis/meta/v1/api_group_list.rs
@@ -11,7 +11,10 @@ impl crate::Resource for APIGroupList {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIGroupList";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIGroupList {

--- a/src/v1_15/apimachinery/pkg/apis/meta/v1/api_resource_list.rs
+++ b/src/v1_15/apimachinery/pkg/apis/meta/v1/api_resource_list.rs
@@ -14,7 +14,10 @@ impl crate::Resource for APIResourceList {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIResourceList";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIResourceList {

--- a/src/v1_15/apimachinery/pkg/apis/meta/v1/api_versions.rs
+++ b/src/v1_15/apimachinery/pkg/apis/meta/v1/api_versions.rs
@@ -14,7 +14,10 @@ impl crate::Resource for APIVersions {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIVersions";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIVersions {

--- a/src/v1_15/apimachinery/pkg/apis/meta/v1/status.rs
+++ b/src/v1_15/apimachinery/pkg/apis/meta/v1/status.rs
@@ -26,7 +26,10 @@ impl crate::Resource for Status {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Status";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Status {

--- a/src/v1_15/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
+++ b/src/v1_15/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
@@ -549,7 +549,10 @@ impl crate::Resource for APIService {
     const API_VERSION: &'static str = "apiregistration.k8s.io/v1";
     const GROUP: &'static str = "apiregistration.k8s.io";
     const KIND: &'static str = "APIService";
+    const PLURAL_NAME: &'static str = "apiservices";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for APIService {

--- a/src/v1_15/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
+++ b/src/v1_15/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
@@ -549,7 +549,10 @@ impl crate::Resource for APIService {
     const API_VERSION: &'static str = "apiregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "apiregistration.k8s.io";
     const KIND: &'static str = "APIService";
+    const PLURAL_NAME: &'static str = "apiservices";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for APIService {

--- a/src/v1_15/list.rs
+++ b/src/v1_15/list.rs
@@ -14,7 +14,10 @@ impl<T> crate::Resource for List<T> where T: crate::ListableResource {
     const API_VERSION: &'static str = <T as crate::Resource>::API_VERSION;
     const GROUP: &'static str = <T as crate::Resource>::GROUP;
     const KIND: &'static str = <T as crate::ListableResource>::LIST_KIND;
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = <T as crate::Resource>::VERSION;
+    const NAMESPACED: bool = <T as crate::Resource>::NAMESPACED;
+    type Scope = <T as crate::Resource>::Scope;
 }
 
 impl<T> crate::Metadata for List<T> where T: crate::ListableResource {

--- a/src/v1_16/api/admissionregistration/v1/mutating_webhook_configuration.rs
+++ b/src/v1_16/api/admissionregistration/v1/mutating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for MutatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "MutatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "mutatingwebhookconfigurations";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for MutatingWebhookConfiguration {

--- a/src/v1_16/api/admissionregistration/v1/validating_webhook_configuration.rs
+++ b/src/v1_16/api/admissionregistration/v1/validating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for ValidatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "ValidatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "validatingwebhookconfigurations";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ValidatingWebhookConfiguration {

--- a/src/v1_16/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
+++ b/src/v1_16/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for MutatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "MutatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "mutatingwebhookconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for MutatingWebhookConfiguration {

--- a/src/v1_16/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
+++ b/src/v1_16/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for ValidatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "ValidatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "validatingwebhookconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ValidatingWebhookConfiguration {

--- a/src/v1_16/api/apps/v1/controller_revision.rs
+++ b/src/v1_16/api/apps/v1/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_16/api/apps/v1/daemon_set.rs
+++ b/src/v1_16/api/apps/v1/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_16/api/apps/v1/deployment.rs
+++ b/src/v1_16/api/apps/v1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_16/api/apps/v1/replica_set.rs
+++ b/src/v1_16/api/apps/v1/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_16/api/apps/v1/stateful_set.rs
+++ b/src/v1_16/api/apps/v1/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_16/api/apps/v1beta1/controller_revision.rs
+++ b/src/v1_16/api/apps/v1beta1/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_16/api/apps/v1beta1/deployment.rs
+++ b/src/v1_16/api/apps/v1beta1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_16/api/apps/v1beta1/deployment_rollback.rs
+++ b/src/v1_16/api/apps/v1beta1/deployment_rollback.rs
@@ -124,7 +124,10 @@ impl crate::Resource for DeploymentRollback {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DeploymentRollback";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for DeploymentRollback {

--- a/src/v1_16/api/apps/v1beta1/scale.rs
+++ b/src/v1_16/api/apps/v1beta1/scale.rs
@@ -405,7 +405,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_16/api/apps/v1beta1/stateful_set.rs
+++ b/src/v1_16/api/apps/v1beta1/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_16/api/apps/v1beta2/controller_revision.rs
+++ b/src/v1_16/api/apps/v1beta2/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_16/api/apps/v1beta2/daemon_set.rs
+++ b/src/v1_16/api/apps/v1beta2/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_16/api/apps/v1beta2/deployment.rs
+++ b/src/v1_16/api/apps/v1beta2/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_16/api/apps/v1beta2/replica_set.rs
+++ b/src/v1_16/api/apps/v1beta2/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_16/api/apps/v1beta2/scale.rs
+++ b/src/v1_16/api/apps/v1beta2/scale.rs
@@ -597,7 +597,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_16/api/apps/v1beta2/stateful_set.rs
+++ b/src/v1_16/api/apps/v1beta2/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_16/api/auditregistration/v1alpha1/audit_sink.rs
+++ b/src/v1_16/api/auditregistration/v1alpha1/audit_sink.rs
@@ -372,7 +372,10 @@ impl crate::Resource for AuditSink {
     const API_VERSION: &'static str = "auditregistration.k8s.io/v1alpha1";
     const GROUP: &'static str = "auditregistration.k8s.io";
     const KIND: &'static str = "AuditSink";
+    const PLURAL_NAME: &'static str = "auditsinks";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for AuditSink {

--- a/src/v1_16/api/authentication/v1/token_request.rs
+++ b/src/v1_16/api/authentication/v1/token_request.rs
@@ -65,7 +65,10 @@ impl crate::Resource for TokenRequest {
     const API_VERSION: &'static str = "authentication.k8s.io/v1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenRequest";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenRequest {

--- a/src/v1_16/api/authentication/v1/token_review.rs
+++ b/src/v1_16/api/authentication/v1/token_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for TokenReview {
     const API_VERSION: &'static str = "authentication.k8s.io/v1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenReview";
+    const PLURAL_NAME: &'static str = "tokenreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenReview {

--- a/src/v1_16/api/authentication/v1beta1/token_review.rs
+++ b/src/v1_16/api/authentication/v1beta1/token_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for TokenReview {
     const API_VERSION: &'static str = "authentication.k8s.io/v1beta1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenReview";
+    const PLURAL_NAME: &'static str = "tokenreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenReview {

--- a/src/v1_16/api/authorization/v1/local_subject_access_review.rs
+++ b/src/v1_16/api/authorization/v1/local_subject_access_review.rs
@@ -61,7 +61,10 @@ impl crate::Resource for LocalSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "LocalSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "localsubjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for LocalSubjectAccessReview {

--- a/src/v1_16/api/authorization/v1/self_subject_access_review.rs
+++ b/src/v1_16/api/authorization/v1/self_subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "selfsubjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectAccessReview {

--- a/src/v1_16/api/authorization/v1/self_subject_rules_review.rs
+++ b/src/v1_16/api/authorization/v1/self_subject_rules_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectRulesReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectRulesReview";
+    const PLURAL_NAME: &'static str = "selfsubjectrulesreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectRulesReview {

--- a/src/v1_16/api/authorization/v1/subject_access_review.rs
+++ b/src/v1_16/api/authorization/v1/subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SubjectAccessReview";
+    const PLURAL_NAME: &'static str = "subjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SubjectAccessReview {

--- a/src/v1_16/api/authorization/v1beta1/local_subject_access_review.rs
+++ b/src/v1_16/api/authorization/v1beta1/local_subject_access_review.rs
@@ -61,7 +61,10 @@ impl crate::Resource for LocalSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "LocalSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "localsubjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for LocalSubjectAccessReview {

--- a/src/v1_16/api/authorization/v1beta1/self_subject_access_review.rs
+++ b/src/v1_16/api/authorization/v1beta1/self_subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "selfsubjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectAccessReview {

--- a/src/v1_16/api/authorization/v1beta1/self_subject_rules_review.rs
+++ b/src/v1_16/api/authorization/v1beta1/self_subject_rules_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectRulesReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectRulesReview";
+    const PLURAL_NAME: &'static str = "selfsubjectrulesreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectRulesReview {

--- a/src/v1_16/api/authorization/v1beta1/subject_access_review.rs
+++ b/src/v1_16/api/authorization/v1beta1/subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SubjectAccessReview";
+    const PLURAL_NAME: &'static str = "subjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SubjectAccessReview {

--- a/src/v1_16/api/autoscaling/v1/horizontal_pod_autoscaler.rs
+++ b/src/v1_16/api/autoscaling/v1/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_16/api/autoscaling/v1/scale.rs
+++ b/src/v1_16/api/autoscaling/v1/scale.rs
@@ -789,7 +789,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "autoscaling/v1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_16/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
+++ b/src/v1_16/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v2beta1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v2beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_16/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
+++ b/src/v1_16/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v2beta2";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v2beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_16/api/batch/v1/job.rs
+++ b/src/v1_16/api/batch/v1/job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Job {
     const API_VERSION: &'static str = "batch/v1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "Job";
+    const PLURAL_NAME: &'static str = "jobs";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Job {

--- a/src/v1_16/api/batch/v1beta1/cron_job.rs
+++ b/src/v1_16/api/batch/v1beta1/cron_job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for CronJob {
     const API_VERSION: &'static str = "batch/v1beta1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "CronJob";
+    const PLURAL_NAME: &'static str = "cronjobs";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CronJob {

--- a/src/v1_16/api/batch/v2alpha1/cron_job.rs
+++ b/src/v1_16/api/batch/v2alpha1/cron_job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for CronJob {
     const API_VERSION: &'static str = "batch/v2alpha1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "CronJob";
+    const PLURAL_NAME: &'static str = "cronjobs";
     const VERSION: &'static str = "v2alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CronJob {

--- a/src/v1_16/api/certificates/v1beta1/certificate_signing_request.rs
+++ b/src/v1_16/api/certificates/v1beta1/certificate_signing_request.rs
@@ -590,7 +590,10 @@ impl crate::Resource for CertificateSigningRequest {
     const API_VERSION: &'static str = "certificates.k8s.io/v1beta1";
     const GROUP: &'static str = "certificates.k8s.io";
     const KIND: &'static str = "CertificateSigningRequest";
+    const PLURAL_NAME: &'static str = "certificatesigningrequests";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CertificateSigningRequest {

--- a/src/v1_16/api/coordination/v1/lease.rs
+++ b/src/v1_16/api/coordination/v1/lease.rs
@@ -489,7 +489,10 @@ impl crate::Resource for Lease {
     const API_VERSION: &'static str = "coordination.k8s.io/v1";
     const GROUP: &'static str = "coordination.k8s.io";
     const KIND: &'static str = "Lease";
+    const PLURAL_NAME: &'static str = "leases";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Lease {

--- a/src/v1_16/api/coordination/v1beta1/lease.rs
+++ b/src/v1_16/api/coordination/v1beta1/lease.rs
@@ -489,7 +489,10 @@ impl crate::Resource for Lease {
     const API_VERSION: &'static str = "coordination.k8s.io/v1beta1";
     const GROUP: &'static str = "coordination.k8s.io";
     const KIND: &'static str = "Lease";
+    const PLURAL_NAME: &'static str = "leases";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Lease {

--- a/src/v1_16/api/core/v1/binding.rs
+++ b/src/v1_16/api/core/v1/binding.rs
@@ -106,7 +106,10 @@ impl crate::Resource for Binding {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Binding";
+    const PLURAL_NAME: &'static str = "bindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for Binding {

--- a/src/v1_16/api/core/v1/component_status.rs
+++ b/src/v1_16/api/core/v1/component_status.rs
@@ -170,7 +170,10 @@ impl crate::Resource for ComponentStatus {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ComponentStatus";
+    const PLURAL_NAME: &'static str = "componentstatuses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ComponentStatus {

--- a/src/v1_16/api/core/v1/config_map.rs
+++ b/src/v1_16/api/core/v1/config_map.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ConfigMap {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ConfigMap";
+    const PLURAL_NAME: &'static str = "configmaps";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ConfigMap {

--- a/src/v1_16/api/core/v1/endpoints.rs
+++ b/src/v1_16/api/core/v1/endpoints.rs
@@ -500,7 +500,10 @@ impl crate::Resource for Endpoints {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Endpoints";
+    const PLURAL_NAME: &'static str = "endpoints";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Endpoints {

--- a/src/v1_16/api/core/v1/event.rs
+++ b/src/v1_16/api/core/v1/event.rs
@@ -528,7 +528,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_16/api/core/v1/limit_range.rs
+++ b/src/v1_16/api/core/v1/limit_range.rs
@@ -489,7 +489,10 @@ impl crate::Resource for LimitRange {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "LimitRange";
+    const PLURAL_NAME: &'static str = "limitranges";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for LimitRange {

--- a/src/v1_16/api/core/v1/namespace.rs
+++ b/src/v1_16/api/core/v1/namespace.rs
@@ -555,7 +555,10 @@ impl crate::Resource for Namespace {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Namespace";
+    const PLURAL_NAME: &'static str = "namespaces";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for Namespace {

--- a/src/v1_16/api/core/v1/node.rs
+++ b/src/v1_16/api/core/v1/node.rs
@@ -1030,7 +1030,10 @@ impl crate::Resource for Node {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Node";
+    const PLURAL_NAME: &'static str = "nodes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for Node {

--- a/src/v1_16/api/core/v1/persistent_volume.rs
+++ b/src/v1_16/api/core/v1/persistent_volume.rs
@@ -550,7 +550,10 @@ impl crate::Resource for PersistentVolume {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PersistentVolume";
+    const PLURAL_NAME: &'static str = "persistentvolumes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PersistentVolume {

--- a/src/v1_16/api/core/v1/persistent_volume_claim.rs
+++ b/src/v1_16/api/core/v1/persistent_volume_claim.rs
@@ -684,7 +684,10 @@ impl crate::Resource for PersistentVolumeClaim {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PersistentVolumeClaim";
+    const PLURAL_NAME: &'static str = "persistentvolumeclaims";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PersistentVolumeClaim {

--- a/src/v1_16/api/core/v1/pod.rs
+++ b/src/v1_16/api/core/v1/pod.rs
@@ -1784,7 +1784,10 @@ impl crate::Resource for Pod {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Pod";
+    const PLURAL_NAME: &'static str = "pods";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Pod {

--- a/src/v1_16/api/core/v1/pod_template.rs
+++ b/src/v1_16/api/core/v1/pod_template.rs
@@ -489,7 +489,10 @@ impl crate::Resource for PodTemplate {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PodTemplate";
+    const PLURAL_NAME: &'static str = "podtemplates";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodTemplate {

--- a/src/v1_16/api/core/v1/replication_controller.rs
+++ b/src/v1_16/api/core/v1/replication_controller.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicationController {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ReplicationController";
+    const PLURAL_NAME: &'static str = "replicationcontrollers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicationController {

--- a/src/v1_16/api/core/v1/resource_quota.rs
+++ b/src/v1_16/api/core/v1/resource_quota.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ResourceQuota {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ResourceQuota";
+    const PLURAL_NAME: &'static str = "resourcequotas";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ResourceQuota {

--- a/src/v1_16/api/core/v1/secret.rs
+++ b/src/v1_16/api/core/v1/secret.rs
@@ -495,7 +495,10 @@ impl crate::Resource for Secret {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Secret";
+    const PLURAL_NAME: &'static str = "secrets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Secret {

--- a/src/v1_16/api/core/v1/service.rs
+++ b/src/v1_16/api/core/v1/service.rs
@@ -1181,7 +1181,10 @@ impl crate::Resource for Service {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Service";
+    const PLURAL_NAME: &'static str = "services";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Service {

--- a/src/v1_16/api/core/v1/service_account.rs
+++ b/src/v1_16/api/core/v1/service_account.rs
@@ -495,7 +495,10 @@ impl crate::Resource for ServiceAccount {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ServiceAccount";
+    const PLURAL_NAME: &'static str = "serviceaccounts";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ServiceAccount {

--- a/src/v1_16/api/discovery/v1alpha1/endpoint_slice.rs
+++ b/src/v1_16/api/discovery/v1alpha1/endpoint_slice.rs
@@ -495,7 +495,10 @@ impl crate::Resource for EndpointSlice {
     const API_VERSION: &'static str = "discovery.k8s.io/v1alpha1";
     const GROUP: &'static str = "discovery.k8s.io";
     const KIND: &'static str = "EndpointSlice";
+    const PLURAL_NAME: &'static str = "endpointslices";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for EndpointSlice {

--- a/src/v1_16/api/events/v1beta1/event.rs
+++ b/src/v1_16/api/events/v1beta1/event.rs
@@ -527,7 +527,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "events.k8s.io/v1beta1";
     const GROUP: &'static str = "events.k8s.io";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_16/api/extensions/v1beta1/daemon_set.rs
+++ b/src/v1_16/api/extensions/v1beta1/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_16/api/extensions/v1beta1/deployment.rs
+++ b/src/v1_16/api/extensions/v1beta1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_16/api/extensions/v1beta1/deployment_rollback.rs
+++ b/src/v1_16/api/extensions/v1beta1/deployment_rollback.rs
@@ -124,7 +124,10 @@ impl crate::Resource for DeploymentRollback {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "DeploymentRollback";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for DeploymentRollback {

--- a/src/v1_16/api/extensions/v1beta1/ingress.rs
+++ b/src/v1_16/api/extensions/v1beta1/ingress.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Ingress {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Ingress";
+    const PLURAL_NAME: &'static str = "ingresses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Ingress {

--- a/src/v1_16/api/extensions/v1beta1/network_policy.rs
+++ b/src/v1_16/api/extensions/v1beta1/network_policy.rs
@@ -489,7 +489,10 @@ impl crate::Resource for NetworkPolicy {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "NetworkPolicy";
+    const PLURAL_NAME: &'static str = "networkpolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for NetworkPolicy {

--- a/src/v1_16/api/extensions/v1beta1/pod_security_policy.rs
+++ b/src/v1_16/api/extensions/v1beta1/pod_security_policy.rs
@@ -373,7 +373,10 @@ impl crate::Resource for PodSecurityPolicy {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "PodSecurityPolicy";
+    const PLURAL_NAME: &'static str = "podsecuritypolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PodSecurityPolicy {

--- a/src/v1_16/api/extensions/v1beta1/replica_set.rs
+++ b/src/v1_16/api/extensions/v1beta1/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_16/api/extensions/v1beta1/scale.rs
+++ b/src/v1_16/api/extensions/v1beta1/scale.rs
@@ -597,7 +597,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_16/api/networking/v1/network_policy.rs
+++ b/src/v1_16/api/networking/v1/network_policy.rs
@@ -489,7 +489,10 @@ impl crate::Resource for NetworkPolicy {
     const API_VERSION: &'static str = "networking.k8s.io/v1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "NetworkPolicy";
+    const PLURAL_NAME: &'static str = "networkpolicies";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for NetworkPolicy {

--- a/src/v1_16/api/networking/v1beta1/ingress.rs
+++ b/src/v1_16/api/networking/v1beta1/ingress.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Ingress {
     const API_VERSION: &'static str = "networking.k8s.io/v1beta1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "Ingress";
+    const PLURAL_NAME: &'static str = "ingresses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Ingress {

--- a/src/v1_16/api/node/v1alpha1/runtime_class.rs
+++ b/src/v1_16/api/node/v1alpha1/runtime_class.rs
@@ -373,7 +373,10 @@ impl crate::Resource for RuntimeClass {
     const API_VERSION: &'static str = "node.k8s.io/v1alpha1";
     const GROUP: &'static str = "node.k8s.io";
     const KIND: &'static str = "RuntimeClass";
+    const PLURAL_NAME: &'static str = "runtimeclasses";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for RuntimeClass {

--- a/src/v1_16/api/node/v1beta1/runtime_class.rs
+++ b/src/v1_16/api/node/v1beta1/runtime_class.rs
@@ -379,7 +379,10 @@ impl crate::Resource for RuntimeClass {
     const API_VERSION: &'static str = "node.k8s.io/v1beta1";
     const GROUP: &'static str = "node.k8s.io";
     const KIND: &'static str = "RuntimeClass";
+    const PLURAL_NAME: &'static str = "runtimeclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for RuntimeClass {

--- a/src/v1_16/api/policy/v1beta1/eviction.rs
+++ b/src/v1_16/api/policy/v1beta1/eviction.rs
@@ -65,7 +65,10 @@ impl crate::Resource for Eviction {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "Eviction";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Eviction {

--- a/src/v1_16/api/policy/v1beta1/pod_disruption_budget.rs
+++ b/src/v1_16/api/policy/v1beta1/pod_disruption_budget.rs
@@ -683,7 +683,10 @@ impl crate::Resource for PodDisruptionBudget {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "PodDisruptionBudget";
+    const PLURAL_NAME: &'static str = "poddisruptionbudgets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodDisruptionBudget {

--- a/src/v1_16/api/policy/v1beta1/pod_security_policy.rs
+++ b/src/v1_16/api/policy/v1beta1/pod_security_policy.rs
@@ -373,7 +373,10 @@ impl crate::Resource for PodSecurityPolicy {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "PodSecurityPolicy";
+    const PLURAL_NAME: &'static str = "podsecuritypolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PodSecurityPolicy {

--- a/src/v1_16/api/rbac/v1/cluster_role.rs
+++ b/src/v1_16/api/rbac/v1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_16/api/rbac/v1/cluster_role_binding.rs
+++ b/src/v1_16/api/rbac/v1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_16/api/rbac/v1/role.rs
+++ b/src/v1_16/api/rbac/v1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_16/api/rbac/v1/role_binding.rs
+++ b/src/v1_16/api/rbac/v1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_16/api/rbac/v1alpha1/cluster_role.rs
+++ b/src/v1_16/api/rbac/v1alpha1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_16/api/rbac/v1alpha1/cluster_role_binding.rs
+++ b/src/v1_16/api/rbac/v1alpha1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_16/api/rbac/v1alpha1/role.rs
+++ b/src/v1_16/api/rbac/v1alpha1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_16/api/rbac/v1alpha1/role_binding.rs
+++ b/src/v1_16/api/rbac/v1alpha1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_16/api/rbac/v1beta1/cluster_role.rs
+++ b/src/v1_16/api/rbac/v1beta1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_16/api/rbac/v1beta1/cluster_role_binding.rs
+++ b/src/v1_16/api/rbac/v1beta1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_16/api/rbac/v1beta1/role.rs
+++ b/src/v1_16/api/rbac/v1beta1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_16/api/rbac/v1beta1/role_binding.rs
+++ b/src/v1_16/api/rbac/v1beta1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_16/api/scheduling/v1/priority_class.rs
+++ b/src/v1_16/api/scheduling/v1/priority_class.rs
@@ -382,7 +382,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_16/api/scheduling/v1alpha1/priority_class.rs
+++ b/src/v1_16/api/scheduling/v1alpha1/priority_class.rs
@@ -382,7 +382,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1alpha1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_16/api/scheduling/v1beta1/priority_class.rs
+++ b/src/v1_16/api/scheduling/v1beta1/priority_class.rs
@@ -382,7 +382,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1beta1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_16/api/settings/v1alpha1/pod_preset.rs
+++ b/src/v1_16/api/settings/v1alpha1/pod_preset.rs
@@ -487,7 +487,10 @@ impl crate::Resource for PodPreset {
     const API_VERSION: &'static str = "settings.k8s.io/v1alpha1";
     const GROUP: &'static str = "settings.k8s.io";
     const KIND: &'static str = "PodPreset";
+    const PLURAL_NAME: &'static str = "podpresets";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodPreset {

--- a/src/v1_16/api/storage/v1/storage_class.rs
+++ b/src/v1_16/api/storage/v1/storage_class.rs
@@ -393,7 +393,10 @@ impl crate::Resource for StorageClass {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "StorageClass";
+    const PLURAL_NAME: &'static str = "storageclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageClass {

--- a/src/v1_16/api/storage/v1/volume_attachment.rs
+++ b/src/v1_16/api/storage/v1/volume_attachment.rs
@@ -552,7 +552,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_16/api/storage/v1alpha1/volume_attachment.rs
+++ b/src/v1_16/api/storage/v1alpha1/volume_attachment.rs
@@ -378,7 +378,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1alpha1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_16/api/storage/v1beta1/csi_driver.rs
+++ b/src/v1_16/api/storage/v1beta1/csi_driver.rs
@@ -373,7 +373,10 @@ impl crate::Resource for CSIDriver {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSIDriver";
+    const PLURAL_NAME: &'static str = "csidrivers";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSIDriver {

--- a/src/v1_16/api/storage/v1beta1/csi_node.rs
+++ b/src/v1_16/api/storage/v1beta1/csi_node.rs
@@ -373,7 +373,10 @@ impl crate::Resource for CSINode {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSINode";
+    const PLURAL_NAME: &'static str = "csinodes";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSINode {

--- a/src/v1_16/api/storage/v1beta1/storage_class.rs
+++ b/src/v1_16/api/storage/v1beta1/storage_class.rs
@@ -393,7 +393,10 @@ impl crate::Resource for StorageClass {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "StorageClass";
+    const PLURAL_NAME: &'static str = "storageclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageClass {

--- a/src/v1_16/api/storage/v1beta1/volume_attachment.rs
+++ b/src/v1_16/api/storage/v1beta1/volume_attachment.rs
@@ -378,7 +378,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_16/apiextensions_apiserver/pkg/apis/apiextensions/v1/custom_resource_definition.rs
+++ b/src/v1_16/apiextensions_apiserver/pkg/apis/apiextensions/v1/custom_resource_definition.rs
@@ -549,7 +549,10 @@ impl crate::Resource for CustomResourceDefinition {
     const API_VERSION: &'static str = "apiextensions.k8s.io/v1";
     const GROUP: &'static str = "apiextensions.k8s.io";
     const KIND: &'static str = "CustomResourceDefinition";
+    const PLURAL_NAME: &'static str = "customresourcedefinitions";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CustomResourceDefinition {

--- a/src/v1_16/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
+++ b/src/v1_16/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
@@ -549,7 +549,10 @@ impl crate::Resource for CustomResourceDefinition {
     const API_VERSION: &'static str = "apiextensions.k8s.io/v1beta1";
     const GROUP: &'static str = "apiextensions.k8s.io";
     const KIND: &'static str = "CustomResourceDefinition";
+    const PLURAL_NAME: &'static str = "customresourcedefinitions";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CustomResourceDefinition {

--- a/src/v1_16/apimachinery/pkg/apis/meta/v1/api_group.rs
+++ b/src/v1_16/apimachinery/pkg/apis/meta/v1/api_group.rs
@@ -20,7 +20,10 @@ impl crate::Resource for APIGroup {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIGroup";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIGroup {

--- a/src/v1_16/apimachinery/pkg/apis/meta/v1/api_group_list.rs
+++ b/src/v1_16/apimachinery/pkg/apis/meta/v1/api_group_list.rs
@@ -11,7 +11,10 @@ impl crate::Resource for APIGroupList {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIGroupList";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIGroupList {

--- a/src/v1_16/apimachinery/pkg/apis/meta/v1/api_resource_list.rs
+++ b/src/v1_16/apimachinery/pkg/apis/meta/v1/api_resource_list.rs
@@ -14,7 +14,10 @@ impl crate::Resource for APIResourceList {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIResourceList";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIResourceList {

--- a/src/v1_16/apimachinery/pkg/apis/meta/v1/api_versions.rs
+++ b/src/v1_16/apimachinery/pkg/apis/meta/v1/api_versions.rs
@@ -14,7 +14,10 @@ impl crate::Resource for APIVersions {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIVersions";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIVersions {

--- a/src/v1_16/apimachinery/pkg/apis/meta/v1/status.rs
+++ b/src/v1_16/apimachinery/pkg/apis/meta/v1/status.rs
@@ -26,7 +26,10 @@ impl crate::Resource for Status {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Status";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Status {

--- a/src/v1_16/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
+++ b/src/v1_16/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
@@ -549,7 +549,10 @@ impl crate::Resource for APIService {
     const API_VERSION: &'static str = "apiregistration.k8s.io/v1";
     const GROUP: &'static str = "apiregistration.k8s.io";
     const KIND: &'static str = "APIService";
+    const PLURAL_NAME: &'static str = "apiservices";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for APIService {

--- a/src/v1_16/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
+++ b/src/v1_16/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
@@ -549,7 +549,10 @@ impl crate::Resource for APIService {
     const API_VERSION: &'static str = "apiregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "apiregistration.k8s.io";
     const KIND: &'static str = "APIService";
+    const PLURAL_NAME: &'static str = "apiservices";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for APIService {

--- a/src/v1_16/list.rs
+++ b/src/v1_16/list.rs
@@ -14,7 +14,10 @@ impl<T> crate::Resource for List<T> where T: crate::ListableResource {
     const API_VERSION: &'static str = <T as crate::Resource>::API_VERSION;
     const GROUP: &'static str = <T as crate::Resource>::GROUP;
     const KIND: &'static str = <T as crate::ListableResource>::LIST_KIND;
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = <T as crate::Resource>::VERSION;
+    const NAMESPACED: bool = <T as crate::Resource>::NAMESPACED;
+    type Scope = <T as crate::Resource>::Scope;
 }
 
 impl<T> crate::Metadata for List<T> where T: crate::ListableResource {

--- a/src/v1_17/api/admissionregistration/v1/mutating_webhook_configuration.rs
+++ b/src/v1_17/api/admissionregistration/v1/mutating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for MutatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "MutatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "mutatingwebhookconfigurations";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for MutatingWebhookConfiguration {

--- a/src/v1_17/api/admissionregistration/v1/validating_webhook_configuration.rs
+++ b/src/v1_17/api/admissionregistration/v1/validating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for ValidatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "ValidatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "validatingwebhookconfigurations";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ValidatingWebhookConfiguration {

--- a/src/v1_17/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
+++ b/src/v1_17/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for MutatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "MutatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "mutatingwebhookconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for MutatingWebhookConfiguration {

--- a/src/v1_17/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
+++ b/src/v1_17/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for ValidatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "ValidatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "validatingwebhookconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ValidatingWebhookConfiguration {

--- a/src/v1_17/api/apps/v1/controller_revision.rs
+++ b/src/v1_17/api/apps/v1/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_17/api/apps/v1/daemon_set.rs
+++ b/src/v1_17/api/apps/v1/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_17/api/apps/v1/deployment.rs
+++ b/src/v1_17/api/apps/v1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_17/api/apps/v1/replica_set.rs
+++ b/src/v1_17/api/apps/v1/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_17/api/apps/v1/stateful_set.rs
+++ b/src/v1_17/api/apps/v1/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_17/api/apps/v1beta1/controller_revision.rs
+++ b/src/v1_17/api/apps/v1beta1/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_17/api/apps/v1beta1/deployment.rs
+++ b/src/v1_17/api/apps/v1beta1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_17/api/apps/v1beta1/deployment_rollback.rs
+++ b/src/v1_17/api/apps/v1beta1/deployment_rollback.rs
@@ -124,7 +124,10 @@ impl crate::Resource for DeploymentRollback {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DeploymentRollback";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for DeploymentRollback {

--- a/src/v1_17/api/apps/v1beta1/scale.rs
+++ b/src/v1_17/api/apps/v1beta1/scale.rs
@@ -405,7 +405,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_17/api/apps/v1beta1/stateful_set.rs
+++ b/src/v1_17/api/apps/v1beta1/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1beta1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_17/api/apps/v1beta2/controller_revision.rs
+++ b/src/v1_17/api/apps/v1beta2/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_17/api/apps/v1beta2/daemon_set.rs
+++ b/src/v1_17/api/apps/v1beta2/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_17/api/apps/v1beta2/deployment.rs
+++ b/src/v1_17/api/apps/v1beta2/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_17/api/apps/v1beta2/replica_set.rs
+++ b/src/v1_17/api/apps/v1beta2/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_17/api/apps/v1beta2/scale.rs
+++ b/src/v1_17/api/apps/v1beta2/scale.rs
@@ -597,7 +597,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_17/api/apps/v1beta2/stateful_set.rs
+++ b/src/v1_17/api/apps/v1beta2/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1beta2";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_17/api/auditregistration/v1alpha1/audit_sink.rs
+++ b/src/v1_17/api/auditregistration/v1alpha1/audit_sink.rs
@@ -372,7 +372,10 @@ impl crate::Resource for AuditSink {
     const API_VERSION: &'static str = "auditregistration.k8s.io/v1alpha1";
     const GROUP: &'static str = "auditregistration.k8s.io";
     const KIND: &'static str = "AuditSink";
+    const PLURAL_NAME: &'static str = "auditsinks";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for AuditSink {

--- a/src/v1_17/api/authentication/v1/token_request.rs
+++ b/src/v1_17/api/authentication/v1/token_request.rs
@@ -65,7 +65,10 @@ impl crate::Resource for TokenRequest {
     const API_VERSION: &'static str = "authentication.k8s.io/v1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenRequest";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenRequest {

--- a/src/v1_17/api/authentication/v1/token_review.rs
+++ b/src/v1_17/api/authentication/v1/token_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for TokenReview {
     const API_VERSION: &'static str = "authentication.k8s.io/v1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenReview";
+    const PLURAL_NAME: &'static str = "tokenreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenReview {

--- a/src/v1_17/api/authentication/v1beta1/token_review.rs
+++ b/src/v1_17/api/authentication/v1beta1/token_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for TokenReview {
     const API_VERSION: &'static str = "authentication.k8s.io/v1beta1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenReview";
+    const PLURAL_NAME: &'static str = "tokenreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenReview {

--- a/src/v1_17/api/authorization/v1/local_subject_access_review.rs
+++ b/src/v1_17/api/authorization/v1/local_subject_access_review.rs
@@ -61,7 +61,10 @@ impl crate::Resource for LocalSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "LocalSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "localsubjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for LocalSubjectAccessReview {

--- a/src/v1_17/api/authorization/v1/self_subject_access_review.rs
+++ b/src/v1_17/api/authorization/v1/self_subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "selfsubjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectAccessReview {

--- a/src/v1_17/api/authorization/v1/self_subject_rules_review.rs
+++ b/src/v1_17/api/authorization/v1/self_subject_rules_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectRulesReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectRulesReview";
+    const PLURAL_NAME: &'static str = "selfsubjectrulesreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectRulesReview {

--- a/src/v1_17/api/authorization/v1/subject_access_review.rs
+++ b/src/v1_17/api/authorization/v1/subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SubjectAccessReview";
+    const PLURAL_NAME: &'static str = "subjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SubjectAccessReview {

--- a/src/v1_17/api/authorization/v1beta1/local_subject_access_review.rs
+++ b/src/v1_17/api/authorization/v1beta1/local_subject_access_review.rs
@@ -61,7 +61,10 @@ impl crate::Resource for LocalSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "LocalSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "localsubjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for LocalSubjectAccessReview {

--- a/src/v1_17/api/authorization/v1beta1/self_subject_access_review.rs
+++ b/src/v1_17/api/authorization/v1beta1/self_subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "selfsubjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectAccessReview {

--- a/src/v1_17/api/authorization/v1beta1/self_subject_rules_review.rs
+++ b/src/v1_17/api/authorization/v1beta1/self_subject_rules_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectRulesReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectRulesReview";
+    const PLURAL_NAME: &'static str = "selfsubjectrulesreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectRulesReview {

--- a/src/v1_17/api/authorization/v1beta1/subject_access_review.rs
+++ b/src/v1_17/api/authorization/v1beta1/subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SubjectAccessReview";
+    const PLURAL_NAME: &'static str = "subjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SubjectAccessReview {

--- a/src/v1_17/api/autoscaling/v1/horizontal_pod_autoscaler.rs
+++ b/src/v1_17/api/autoscaling/v1/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_17/api/autoscaling/v1/scale.rs
+++ b/src/v1_17/api/autoscaling/v1/scale.rs
@@ -789,7 +789,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "autoscaling/v1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_17/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
+++ b/src/v1_17/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v2beta1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v2beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_17/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
+++ b/src/v1_17/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v2beta2";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v2beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_17/api/batch/v1/job.rs
+++ b/src/v1_17/api/batch/v1/job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Job {
     const API_VERSION: &'static str = "batch/v1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "Job";
+    const PLURAL_NAME: &'static str = "jobs";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Job {

--- a/src/v1_17/api/batch/v1beta1/cron_job.rs
+++ b/src/v1_17/api/batch/v1beta1/cron_job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for CronJob {
     const API_VERSION: &'static str = "batch/v1beta1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "CronJob";
+    const PLURAL_NAME: &'static str = "cronjobs";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CronJob {

--- a/src/v1_17/api/batch/v2alpha1/cron_job.rs
+++ b/src/v1_17/api/batch/v2alpha1/cron_job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for CronJob {
     const API_VERSION: &'static str = "batch/v2alpha1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "CronJob";
+    const PLURAL_NAME: &'static str = "cronjobs";
     const VERSION: &'static str = "v2alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CronJob {

--- a/src/v1_17/api/certificates/v1beta1/certificate_signing_request.rs
+++ b/src/v1_17/api/certificates/v1beta1/certificate_signing_request.rs
@@ -590,7 +590,10 @@ impl crate::Resource for CertificateSigningRequest {
     const API_VERSION: &'static str = "certificates.k8s.io/v1beta1";
     const GROUP: &'static str = "certificates.k8s.io";
     const KIND: &'static str = "CertificateSigningRequest";
+    const PLURAL_NAME: &'static str = "certificatesigningrequests";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CertificateSigningRequest {

--- a/src/v1_17/api/coordination/v1/lease.rs
+++ b/src/v1_17/api/coordination/v1/lease.rs
@@ -489,7 +489,10 @@ impl crate::Resource for Lease {
     const API_VERSION: &'static str = "coordination.k8s.io/v1";
     const GROUP: &'static str = "coordination.k8s.io";
     const KIND: &'static str = "Lease";
+    const PLURAL_NAME: &'static str = "leases";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Lease {

--- a/src/v1_17/api/coordination/v1beta1/lease.rs
+++ b/src/v1_17/api/coordination/v1beta1/lease.rs
@@ -489,7 +489,10 @@ impl crate::Resource for Lease {
     const API_VERSION: &'static str = "coordination.k8s.io/v1beta1";
     const GROUP: &'static str = "coordination.k8s.io";
     const KIND: &'static str = "Lease";
+    const PLURAL_NAME: &'static str = "leases";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Lease {

--- a/src/v1_17/api/core/v1/binding.rs
+++ b/src/v1_17/api/core/v1/binding.rs
@@ -106,7 +106,10 @@ impl crate::Resource for Binding {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Binding";
+    const PLURAL_NAME: &'static str = "bindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for Binding {

--- a/src/v1_17/api/core/v1/component_status.rs
+++ b/src/v1_17/api/core/v1/component_status.rs
@@ -170,7 +170,10 @@ impl crate::Resource for ComponentStatus {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ComponentStatus";
+    const PLURAL_NAME: &'static str = "componentstatuses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ComponentStatus {

--- a/src/v1_17/api/core/v1/config_map.rs
+++ b/src/v1_17/api/core/v1/config_map.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ConfigMap {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ConfigMap";
+    const PLURAL_NAME: &'static str = "configmaps";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ConfigMap {

--- a/src/v1_17/api/core/v1/endpoints.rs
+++ b/src/v1_17/api/core/v1/endpoints.rs
@@ -500,7 +500,10 @@ impl crate::Resource for Endpoints {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Endpoints";
+    const PLURAL_NAME: &'static str = "endpoints";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Endpoints {

--- a/src/v1_17/api/core/v1/event.rs
+++ b/src/v1_17/api/core/v1/event.rs
@@ -528,7 +528,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_17/api/core/v1/limit_range.rs
+++ b/src/v1_17/api/core/v1/limit_range.rs
@@ -489,7 +489,10 @@ impl crate::Resource for LimitRange {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "LimitRange";
+    const PLURAL_NAME: &'static str = "limitranges";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for LimitRange {

--- a/src/v1_17/api/core/v1/namespace.rs
+++ b/src/v1_17/api/core/v1/namespace.rs
@@ -555,7 +555,10 @@ impl crate::Resource for Namespace {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Namespace";
+    const PLURAL_NAME: &'static str = "namespaces";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for Namespace {

--- a/src/v1_17/api/core/v1/node.rs
+++ b/src/v1_17/api/core/v1/node.rs
@@ -1030,7 +1030,10 @@ impl crate::Resource for Node {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Node";
+    const PLURAL_NAME: &'static str = "nodes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for Node {

--- a/src/v1_17/api/core/v1/persistent_volume.rs
+++ b/src/v1_17/api/core/v1/persistent_volume.rs
@@ -550,7 +550,10 @@ impl crate::Resource for PersistentVolume {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PersistentVolume";
+    const PLURAL_NAME: &'static str = "persistentvolumes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PersistentVolume {

--- a/src/v1_17/api/core/v1/persistent_volume_claim.rs
+++ b/src/v1_17/api/core/v1/persistent_volume_claim.rs
@@ -684,7 +684,10 @@ impl crate::Resource for PersistentVolumeClaim {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PersistentVolumeClaim";
+    const PLURAL_NAME: &'static str = "persistentvolumeclaims";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PersistentVolumeClaim {

--- a/src/v1_17/api/core/v1/pod.rs
+++ b/src/v1_17/api/core/v1/pod.rs
@@ -1790,7 +1790,10 @@ impl crate::Resource for Pod {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Pod";
+    const PLURAL_NAME: &'static str = "pods";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Pod {

--- a/src/v1_17/api/core/v1/pod_template.rs
+++ b/src/v1_17/api/core/v1/pod_template.rs
@@ -489,7 +489,10 @@ impl crate::Resource for PodTemplate {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PodTemplate";
+    const PLURAL_NAME: &'static str = "podtemplates";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodTemplate {

--- a/src/v1_17/api/core/v1/replication_controller.rs
+++ b/src/v1_17/api/core/v1/replication_controller.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicationController {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ReplicationController";
+    const PLURAL_NAME: &'static str = "replicationcontrollers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicationController {

--- a/src/v1_17/api/core/v1/resource_quota.rs
+++ b/src/v1_17/api/core/v1/resource_quota.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ResourceQuota {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ResourceQuota";
+    const PLURAL_NAME: &'static str = "resourcequotas";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ResourceQuota {

--- a/src/v1_17/api/core/v1/secret.rs
+++ b/src/v1_17/api/core/v1/secret.rs
@@ -495,7 +495,10 @@ impl crate::Resource for Secret {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Secret";
+    const PLURAL_NAME: &'static str = "secrets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Secret {

--- a/src/v1_17/api/core/v1/service.rs
+++ b/src/v1_17/api/core/v1/service.rs
@@ -1181,7 +1181,10 @@ impl crate::Resource for Service {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Service";
+    const PLURAL_NAME: &'static str = "services";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Service {

--- a/src/v1_17/api/core/v1/service_account.rs
+++ b/src/v1_17/api/core/v1/service_account.rs
@@ -495,7 +495,10 @@ impl crate::Resource for ServiceAccount {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ServiceAccount";
+    const PLURAL_NAME: &'static str = "serviceaccounts";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ServiceAccount {

--- a/src/v1_17/api/discovery/v1beta1/endpoint_slice.rs
+++ b/src/v1_17/api/discovery/v1beta1/endpoint_slice.rs
@@ -495,7 +495,10 @@ impl crate::Resource for EndpointSlice {
     const API_VERSION: &'static str = "discovery.k8s.io/v1beta1";
     const GROUP: &'static str = "discovery.k8s.io";
     const KIND: &'static str = "EndpointSlice";
+    const PLURAL_NAME: &'static str = "endpointslices";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for EndpointSlice {

--- a/src/v1_17/api/events/v1beta1/event.rs
+++ b/src/v1_17/api/events/v1beta1/event.rs
@@ -527,7 +527,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "events.k8s.io/v1beta1";
     const GROUP: &'static str = "events.k8s.io";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_17/api/extensions/v1beta1/daemon_set.rs
+++ b/src/v1_17/api/extensions/v1beta1/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_17/api/extensions/v1beta1/deployment.rs
+++ b/src/v1_17/api/extensions/v1beta1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_17/api/extensions/v1beta1/deployment_rollback.rs
+++ b/src/v1_17/api/extensions/v1beta1/deployment_rollback.rs
@@ -124,7 +124,10 @@ impl crate::Resource for DeploymentRollback {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "DeploymentRollback";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for DeploymentRollback {

--- a/src/v1_17/api/extensions/v1beta1/ingress.rs
+++ b/src/v1_17/api/extensions/v1beta1/ingress.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Ingress {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Ingress";
+    const PLURAL_NAME: &'static str = "ingresses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Ingress {

--- a/src/v1_17/api/extensions/v1beta1/network_policy.rs
+++ b/src/v1_17/api/extensions/v1beta1/network_policy.rs
@@ -489,7 +489,10 @@ impl crate::Resource for NetworkPolicy {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "NetworkPolicy";
+    const PLURAL_NAME: &'static str = "networkpolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for NetworkPolicy {

--- a/src/v1_17/api/extensions/v1beta1/pod_security_policy.rs
+++ b/src/v1_17/api/extensions/v1beta1/pod_security_policy.rs
@@ -373,7 +373,10 @@ impl crate::Resource for PodSecurityPolicy {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "PodSecurityPolicy";
+    const PLURAL_NAME: &'static str = "podsecuritypolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PodSecurityPolicy {

--- a/src/v1_17/api/extensions/v1beta1/replica_set.rs
+++ b/src/v1_17/api/extensions/v1beta1/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_17/api/extensions/v1beta1/scale.rs
+++ b/src/v1_17/api/extensions/v1beta1/scale.rs
@@ -597,7 +597,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_17/api/flowcontrol/v1alpha1/flow_schema.rs
+++ b/src/v1_17/api/flowcontrol/v1alpha1/flow_schema.rs
@@ -550,7 +550,10 @@ impl crate::Resource for FlowSchema {
     const API_VERSION: &'static str = "flowcontrol.apiserver.k8s.io/v1alpha1";
     const GROUP: &'static str = "flowcontrol.apiserver.k8s.io";
     const KIND: &'static str = "FlowSchema";
+    const PLURAL_NAME: &'static str = "flowschemas";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for FlowSchema {

--- a/src/v1_17/api/flowcontrol/v1alpha1/priority_level_configuration.rs
+++ b/src/v1_17/api/flowcontrol/v1alpha1/priority_level_configuration.rs
@@ -550,7 +550,10 @@ impl crate::Resource for PriorityLevelConfiguration {
     const API_VERSION: &'static str = "flowcontrol.apiserver.k8s.io/v1alpha1";
     const GROUP: &'static str = "flowcontrol.apiserver.k8s.io";
     const KIND: &'static str = "PriorityLevelConfiguration";
+    const PLURAL_NAME: &'static str = "prioritylevelconfigurations";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityLevelConfiguration {

--- a/src/v1_17/api/networking/v1/network_policy.rs
+++ b/src/v1_17/api/networking/v1/network_policy.rs
@@ -489,7 +489,10 @@ impl crate::Resource for NetworkPolicy {
     const API_VERSION: &'static str = "networking.k8s.io/v1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "NetworkPolicy";
+    const PLURAL_NAME: &'static str = "networkpolicies";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for NetworkPolicy {

--- a/src/v1_17/api/networking/v1beta1/ingress.rs
+++ b/src/v1_17/api/networking/v1beta1/ingress.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Ingress {
     const API_VERSION: &'static str = "networking.k8s.io/v1beta1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "Ingress";
+    const PLURAL_NAME: &'static str = "ingresses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Ingress {

--- a/src/v1_17/api/node/v1alpha1/runtime_class.rs
+++ b/src/v1_17/api/node/v1alpha1/runtime_class.rs
@@ -373,7 +373,10 @@ impl crate::Resource for RuntimeClass {
     const API_VERSION: &'static str = "node.k8s.io/v1alpha1";
     const GROUP: &'static str = "node.k8s.io";
     const KIND: &'static str = "RuntimeClass";
+    const PLURAL_NAME: &'static str = "runtimeclasses";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for RuntimeClass {

--- a/src/v1_17/api/node/v1beta1/runtime_class.rs
+++ b/src/v1_17/api/node/v1beta1/runtime_class.rs
@@ -379,7 +379,10 @@ impl crate::Resource for RuntimeClass {
     const API_VERSION: &'static str = "node.k8s.io/v1beta1";
     const GROUP: &'static str = "node.k8s.io";
     const KIND: &'static str = "RuntimeClass";
+    const PLURAL_NAME: &'static str = "runtimeclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for RuntimeClass {

--- a/src/v1_17/api/policy/v1beta1/eviction.rs
+++ b/src/v1_17/api/policy/v1beta1/eviction.rs
@@ -65,7 +65,10 @@ impl crate::Resource for Eviction {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "Eviction";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Eviction {

--- a/src/v1_17/api/policy/v1beta1/pod_disruption_budget.rs
+++ b/src/v1_17/api/policy/v1beta1/pod_disruption_budget.rs
@@ -683,7 +683,10 @@ impl crate::Resource for PodDisruptionBudget {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "PodDisruptionBudget";
+    const PLURAL_NAME: &'static str = "poddisruptionbudgets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodDisruptionBudget {

--- a/src/v1_17/api/policy/v1beta1/pod_security_policy.rs
+++ b/src/v1_17/api/policy/v1beta1/pod_security_policy.rs
@@ -373,7 +373,10 @@ impl crate::Resource for PodSecurityPolicy {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "PodSecurityPolicy";
+    const PLURAL_NAME: &'static str = "podsecuritypolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PodSecurityPolicy {

--- a/src/v1_17/api/rbac/v1/cluster_role.rs
+++ b/src/v1_17/api/rbac/v1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_17/api/rbac/v1/cluster_role_binding.rs
+++ b/src/v1_17/api/rbac/v1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_17/api/rbac/v1/role.rs
+++ b/src/v1_17/api/rbac/v1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_17/api/rbac/v1/role_binding.rs
+++ b/src/v1_17/api/rbac/v1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_17/api/rbac/v1alpha1/cluster_role.rs
+++ b/src/v1_17/api/rbac/v1alpha1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_17/api/rbac/v1alpha1/cluster_role_binding.rs
+++ b/src/v1_17/api/rbac/v1alpha1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_17/api/rbac/v1alpha1/role.rs
+++ b/src/v1_17/api/rbac/v1alpha1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_17/api/rbac/v1alpha1/role_binding.rs
+++ b/src/v1_17/api/rbac/v1alpha1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_17/api/rbac/v1beta1/cluster_role.rs
+++ b/src/v1_17/api/rbac/v1beta1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_17/api/rbac/v1beta1/cluster_role_binding.rs
+++ b/src/v1_17/api/rbac/v1beta1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_17/api/rbac/v1beta1/role.rs
+++ b/src/v1_17/api/rbac/v1beta1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_17/api/rbac/v1beta1/role_binding.rs
+++ b/src/v1_17/api/rbac/v1beta1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_17/api/scheduling/v1/priority_class.rs
+++ b/src/v1_17/api/scheduling/v1/priority_class.rs
@@ -382,7 +382,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_17/api/scheduling/v1alpha1/priority_class.rs
+++ b/src/v1_17/api/scheduling/v1alpha1/priority_class.rs
@@ -382,7 +382,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1alpha1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_17/api/scheduling/v1beta1/priority_class.rs
+++ b/src/v1_17/api/scheduling/v1beta1/priority_class.rs
@@ -382,7 +382,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1beta1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_17/api/settings/v1alpha1/pod_preset.rs
+++ b/src/v1_17/api/settings/v1alpha1/pod_preset.rs
@@ -487,7 +487,10 @@ impl crate::Resource for PodPreset {
     const API_VERSION: &'static str = "settings.k8s.io/v1alpha1";
     const GROUP: &'static str = "settings.k8s.io";
     const KIND: &'static str = "PodPreset";
+    const PLURAL_NAME: &'static str = "podpresets";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodPreset {

--- a/src/v1_17/api/storage/v1/csi_node.rs
+++ b/src/v1_17/api/storage/v1/csi_node.rs
@@ -373,7 +373,10 @@ impl crate::Resource for CSINode {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSINode";
+    const PLURAL_NAME: &'static str = "csinodes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSINode {

--- a/src/v1_17/api/storage/v1/storage_class.rs
+++ b/src/v1_17/api/storage/v1/storage_class.rs
@@ -393,7 +393,10 @@ impl crate::Resource for StorageClass {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "StorageClass";
+    const PLURAL_NAME: &'static str = "storageclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageClass {

--- a/src/v1_17/api/storage/v1/volume_attachment.rs
+++ b/src/v1_17/api/storage/v1/volume_attachment.rs
@@ -552,7 +552,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_17/api/storage/v1alpha1/volume_attachment.rs
+++ b/src/v1_17/api/storage/v1alpha1/volume_attachment.rs
@@ -378,7 +378,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1alpha1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_17/api/storage/v1beta1/csi_driver.rs
+++ b/src/v1_17/api/storage/v1beta1/csi_driver.rs
@@ -373,7 +373,10 @@ impl crate::Resource for CSIDriver {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSIDriver";
+    const PLURAL_NAME: &'static str = "csidrivers";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSIDriver {

--- a/src/v1_17/api/storage/v1beta1/csi_node.rs
+++ b/src/v1_17/api/storage/v1beta1/csi_node.rs
@@ -373,7 +373,10 @@ impl crate::Resource for CSINode {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSINode";
+    const PLURAL_NAME: &'static str = "csinodes";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSINode {

--- a/src/v1_17/api/storage/v1beta1/storage_class.rs
+++ b/src/v1_17/api/storage/v1beta1/storage_class.rs
@@ -393,7 +393,10 @@ impl crate::Resource for StorageClass {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "StorageClass";
+    const PLURAL_NAME: &'static str = "storageclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageClass {

--- a/src/v1_17/api/storage/v1beta1/volume_attachment.rs
+++ b/src/v1_17/api/storage/v1beta1/volume_attachment.rs
@@ -378,7 +378,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_17/apiextensions_apiserver/pkg/apis/apiextensions/v1/custom_resource_definition.rs
+++ b/src/v1_17/apiextensions_apiserver/pkg/apis/apiextensions/v1/custom_resource_definition.rs
@@ -549,7 +549,10 @@ impl crate::Resource for CustomResourceDefinition {
     const API_VERSION: &'static str = "apiextensions.k8s.io/v1";
     const GROUP: &'static str = "apiextensions.k8s.io";
     const KIND: &'static str = "CustomResourceDefinition";
+    const PLURAL_NAME: &'static str = "customresourcedefinitions";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CustomResourceDefinition {

--- a/src/v1_17/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
+++ b/src/v1_17/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
@@ -549,7 +549,10 @@ impl crate::Resource for CustomResourceDefinition {
     const API_VERSION: &'static str = "apiextensions.k8s.io/v1beta1";
     const GROUP: &'static str = "apiextensions.k8s.io";
     const KIND: &'static str = "CustomResourceDefinition";
+    const PLURAL_NAME: &'static str = "customresourcedefinitions";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CustomResourceDefinition {

--- a/src/v1_17/apimachinery/pkg/apis/meta/v1/api_group.rs
+++ b/src/v1_17/apimachinery/pkg/apis/meta/v1/api_group.rs
@@ -20,7 +20,10 @@ impl crate::Resource for APIGroup {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIGroup";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIGroup {

--- a/src/v1_17/apimachinery/pkg/apis/meta/v1/api_group_list.rs
+++ b/src/v1_17/apimachinery/pkg/apis/meta/v1/api_group_list.rs
@@ -11,7 +11,10 @@ impl crate::Resource for APIGroupList {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIGroupList";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIGroupList {

--- a/src/v1_17/apimachinery/pkg/apis/meta/v1/api_resource_list.rs
+++ b/src/v1_17/apimachinery/pkg/apis/meta/v1/api_resource_list.rs
@@ -14,7 +14,10 @@ impl crate::Resource for APIResourceList {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIResourceList";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIResourceList {

--- a/src/v1_17/apimachinery/pkg/apis/meta/v1/api_versions.rs
+++ b/src/v1_17/apimachinery/pkg/apis/meta/v1/api_versions.rs
@@ -14,7 +14,10 @@ impl crate::Resource for APIVersions {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIVersions";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIVersions {

--- a/src/v1_17/apimachinery/pkg/apis/meta/v1/status.rs
+++ b/src/v1_17/apimachinery/pkg/apis/meta/v1/status.rs
@@ -26,7 +26,10 @@ impl crate::Resource for Status {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Status";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Status {

--- a/src/v1_17/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
+++ b/src/v1_17/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
@@ -549,7 +549,10 @@ impl crate::Resource for APIService {
     const API_VERSION: &'static str = "apiregistration.k8s.io/v1";
     const GROUP: &'static str = "apiregistration.k8s.io";
     const KIND: &'static str = "APIService";
+    const PLURAL_NAME: &'static str = "apiservices";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for APIService {

--- a/src/v1_17/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
+++ b/src/v1_17/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
@@ -549,7 +549,10 @@ impl crate::Resource for APIService {
     const API_VERSION: &'static str = "apiregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "apiregistration.k8s.io";
     const KIND: &'static str = "APIService";
+    const PLURAL_NAME: &'static str = "apiservices";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for APIService {

--- a/src/v1_17/list.rs
+++ b/src/v1_17/list.rs
@@ -14,7 +14,10 @@ impl<T> crate::Resource for List<T> where T: crate::ListableResource {
     const API_VERSION: &'static str = <T as crate::Resource>::API_VERSION;
     const GROUP: &'static str = <T as crate::Resource>::GROUP;
     const KIND: &'static str = <T as crate::ListableResource>::LIST_KIND;
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = <T as crate::Resource>::VERSION;
+    const NAMESPACED: bool = <T as crate::Resource>::NAMESPACED;
+    type Scope = <T as crate::Resource>::Scope;
 }
 
 impl<T> crate::Metadata for List<T> where T: crate::ListableResource {

--- a/src/v1_18/api/admissionregistration/v1/mutating_webhook_configuration.rs
+++ b/src/v1_18/api/admissionregistration/v1/mutating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for MutatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "MutatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "mutatingwebhookconfigurations";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for MutatingWebhookConfiguration {

--- a/src/v1_18/api/admissionregistration/v1/validating_webhook_configuration.rs
+++ b/src/v1_18/api/admissionregistration/v1/validating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for ValidatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "ValidatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "validatingwebhookconfigurations";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ValidatingWebhookConfiguration {

--- a/src/v1_18/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
+++ b/src/v1_18/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for MutatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "MutatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "mutatingwebhookconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for MutatingWebhookConfiguration {

--- a/src/v1_18/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
+++ b/src/v1_18/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for ValidatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "ValidatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "validatingwebhookconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ValidatingWebhookConfiguration {

--- a/src/v1_18/api/apps/v1/controller_revision.rs
+++ b/src/v1_18/api/apps/v1/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_18/api/apps/v1/daemon_set.rs
+++ b/src/v1_18/api/apps/v1/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_18/api/apps/v1/deployment.rs
+++ b/src/v1_18/api/apps/v1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_18/api/apps/v1/replica_set.rs
+++ b/src/v1_18/api/apps/v1/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_18/api/apps/v1/stateful_set.rs
+++ b/src/v1_18/api/apps/v1/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_18/api/auditregistration/v1alpha1/audit_sink.rs
+++ b/src/v1_18/api/auditregistration/v1alpha1/audit_sink.rs
@@ -372,7 +372,10 @@ impl crate::Resource for AuditSink {
     const API_VERSION: &'static str = "auditregistration.k8s.io/v1alpha1";
     const GROUP: &'static str = "auditregistration.k8s.io";
     const KIND: &'static str = "AuditSink";
+    const PLURAL_NAME: &'static str = "auditsinks";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for AuditSink {

--- a/src/v1_18/api/authentication/v1/token_request.rs
+++ b/src/v1_18/api/authentication/v1/token_request.rs
@@ -65,7 +65,10 @@ impl crate::Resource for TokenRequest {
     const API_VERSION: &'static str = "authentication.k8s.io/v1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenRequest";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenRequest {

--- a/src/v1_18/api/authentication/v1/token_review.rs
+++ b/src/v1_18/api/authentication/v1/token_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for TokenReview {
     const API_VERSION: &'static str = "authentication.k8s.io/v1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenReview";
+    const PLURAL_NAME: &'static str = "tokenreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenReview {

--- a/src/v1_18/api/authentication/v1beta1/token_review.rs
+++ b/src/v1_18/api/authentication/v1beta1/token_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for TokenReview {
     const API_VERSION: &'static str = "authentication.k8s.io/v1beta1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenReview";
+    const PLURAL_NAME: &'static str = "tokenreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenReview {

--- a/src/v1_18/api/authorization/v1/local_subject_access_review.rs
+++ b/src/v1_18/api/authorization/v1/local_subject_access_review.rs
@@ -61,7 +61,10 @@ impl crate::Resource for LocalSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "LocalSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "localsubjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for LocalSubjectAccessReview {

--- a/src/v1_18/api/authorization/v1/self_subject_access_review.rs
+++ b/src/v1_18/api/authorization/v1/self_subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "selfsubjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectAccessReview {

--- a/src/v1_18/api/authorization/v1/self_subject_rules_review.rs
+++ b/src/v1_18/api/authorization/v1/self_subject_rules_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectRulesReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectRulesReview";
+    const PLURAL_NAME: &'static str = "selfsubjectrulesreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectRulesReview {

--- a/src/v1_18/api/authorization/v1/subject_access_review.rs
+++ b/src/v1_18/api/authorization/v1/subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SubjectAccessReview";
+    const PLURAL_NAME: &'static str = "subjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SubjectAccessReview {

--- a/src/v1_18/api/authorization/v1beta1/local_subject_access_review.rs
+++ b/src/v1_18/api/authorization/v1beta1/local_subject_access_review.rs
@@ -61,7 +61,10 @@ impl crate::Resource for LocalSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "LocalSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "localsubjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for LocalSubjectAccessReview {

--- a/src/v1_18/api/authorization/v1beta1/self_subject_access_review.rs
+++ b/src/v1_18/api/authorization/v1beta1/self_subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "selfsubjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectAccessReview {

--- a/src/v1_18/api/authorization/v1beta1/self_subject_rules_review.rs
+++ b/src/v1_18/api/authorization/v1beta1/self_subject_rules_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectRulesReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectRulesReview";
+    const PLURAL_NAME: &'static str = "selfsubjectrulesreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectRulesReview {

--- a/src/v1_18/api/authorization/v1beta1/subject_access_review.rs
+++ b/src/v1_18/api/authorization/v1beta1/subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SubjectAccessReview";
+    const PLURAL_NAME: &'static str = "subjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SubjectAccessReview {

--- a/src/v1_18/api/autoscaling/v1/horizontal_pod_autoscaler.rs
+++ b/src/v1_18/api/autoscaling/v1/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_18/api/autoscaling/v1/scale.rs
+++ b/src/v1_18/api/autoscaling/v1/scale.rs
@@ -789,7 +789,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "autoscaling/v1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_18/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
+++ b/src/v1_18/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v2beta1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v2beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_18/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
+++ b/src/v1_18/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v2beta2";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v2beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_18/api/batch/v1/job.rs
+++ b/src/v1_18/api/batch/v1/job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Job {
     const API_VERSION: &'static str = "batch/v1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "Job";
+    const PLURAL_NAME: &'static str = "jobs";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Job {

--- a/src/v1_18/api/batch/v1beta1/cron_job.rs
+++ b/src/v1_18/api/batch/v1beta1/cron_job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for CronJob {
     const API_VERSION: &'static str = "batch/v1beta1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "CronJob";
+    const PLURAL_NAME: &'static str = "cronjobs";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CronJob {

--- a/src/v1_18/api/batch/v2alpha1/cron_job.rs
+++ b/src/v1_18/api/batch/v2alpha1/cron_job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for CronJob {
     const API_VERSION: &'static str = "batch/v2alpha1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "CronJob";
+    const PLURAL_NAME: &'static str = "cronjobs";
     const VERSION: &'static str = "v2alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CronJob {

--- a/src/v1_18/api/certificates/v1beta1/certificate_signing_request.rs
+++ b/src/v1_18/api/certificates/v1beta1/certificate_signing_request.rs
@@ -590,7 +590,10 @@ impl crate::Resource for CertificateSigningRequest {
     const API_VERSION: &'static str = "certificates.k8s.io/v1beta1";
     const GROUP: &'static str = "certificates.k8s.io";
     const KIND: &'static str = "CertificateSigningRequest";
+    const PLURAL_NAME: &'static str = "certificatesigningrequests";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CertificateSigningRequest {

--- a/src/v1_18/api/coordination/v1/lease.rs
+++ b/src/v1_18/api/coordination/v1/lease.rs
@@ -489,7 +489,10 @@ impl crate::Resource for Lease {
     const API_VERSION: &'static str = "coordination.k8s.io/v1";
     const GROUP: &'static str = "coordination.k8s.io";
     const KIND: &'static str = "Lease";
+    const PLURAL_NAME: &'static str = "leases";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Lease {

--- a/src/v1_18/api/coordination/v1beta1/lease.rs
+++ b/src/v1_18/api/coordination/v1beta1/lease.rs
@@ -489,7 +489,10 @@ impl crate::Resource for Lease {
     const API_VERSION: &'static str = "coordination.k8s.io/v1beta1";
     const GROUP: &'static str = "coordination.k8s.io";
     const KIND: &'static str = "Lease";
+    const PLURAL_NAME: &'static str = "leases";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Lease {

--- a/src/v1_18/api/core/v1/binding.rs
+++ b/src/v1_18/api/core/v1/binding.rs
@@ -106,7 +106,10 @@ impl crate::Resource for Binding {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Binding";
+    const PLURAL_NAME: &'static str = "bindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for Binding {

--- a/src/v1_18/api/core/v1/component_status.rs
+++ b/src/v1_18/api/core/v1/component_status.rs
@@ -170,7 +170,10 @@ impl crate::Resource for ComponentStatus {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ComponentStatus";
+    const PLURAL_NAME: &'static str = "componentstatuses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ComponentStatus {

--- a/src/v1_18/api/core/v1/config_map.rs
+++ b/src/v1_18/api/core/v1/config_map.rs
@@ -495,7 +495,10 @@ impl crate::Resource for ConfigMap {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ConfigMap";
+    const PLURAL_NAME: &'static str = "configmaps";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ConfigMap {

--- a/src/v1_18/api/core/v1/endpoints.rs
+++ b/src/v1_18/api/core/v1/endpoints.rs
@@ -500,7 +500,10 @@ impl crate::Resource for Endpoints {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Endpoints";
+    const PLURAL_NAME: &'static str = "endpoints";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Endpoints {

--- a/src/v1_18/api/core/v1/event.rs
+++ b/src/v1_18/api/core/v1/event.rs
@@ -528,7 +528,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_18/api/core/v1/limit_range.rs
+++ b/src/v1_18/api/core/v1/limit_range.rs
@@ -489,7 +489,10 @@ impl crate::Resource for LimitRange {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "LimitRange";
+    const PLURAL_NAME: &'static str = "limitranges";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for LimitRange {

--- a/src/v1_18/api/core/v1/namespace.rs
+++ b/src/v1_18/api/core/v1/namespace.rs
@@ -555,7 +555,10 @@ impl crate::Resource for Namespace {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Namespace";
+    const PLURAL_NAME: &'static str = "namespaces";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for Namespace {

--- a/src/v1_18/api/core/v1/node.rs
+++ b/src/v1_18/api/core/v1/node.rs
@@ -1030,7 +1030,10 @@ impl crate::Resource for Node {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Node";
+    const PLURAL_NAME: &'static str = "nodes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for Node {

--- a/src/v1_18/api/core/v1/persistent_volume.rs
+++ b/src/v1_18/api/core/v1/persistent_volume.rs
@@ -550,7 +550,10 @@ impl crate::Resource for PersistentVolume {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PersistentVolume";
+    const PLURAL_NAME: &'static str = "persistentvolumes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PersistentVolume {

--- a/src/v1_18/api/core/v1/persistent_volume_claim.rs
+++ b/src/v1_18/api/core/v1/persistent_volume_claim.rs
@@ -684,7 +684,10 @@ impl crate::Resource for PersistentVolumeClaim {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PersistentVolumeClaim";
+    const PLURAL_NAME: &'static str = "persistentvolumeclaims";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PersistentVolumeClaim {

--- a/src/v1_18/api/core/v1/pod.rs
+++ b/src/v1_18/api/core/v1/pod.rs
@@ -1790,7 +1790,10 @@ impl crate::Resource for Pod {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Pod";
+    const PLURAL_NAME: &'static str = "pods";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Pod {

--- a/src/v1_18/api/core/v1/pod_template.rs
+++ b/src/v1_18/api/core/v1/pod_template.rs
@@ -489,7 +489,10 @@ impl crate::Resource for PodTemplate {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PodTemplate";
+    const PLURAL_NAME: &'static str = "podtemplates";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodTemplate {

--- a/src/v1_18/api/core/v1/replication_controller.rs
+++ b/src/v1_18/api/core/v1/replication_controller.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicationController {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ReplicationController";
+    const PLURAL_NAME: &'static str = "replicationcontrollers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicationController {

--- a/src/v1_18/api/core/v1/resource_quota.rs
+++ b/src/v1_18/api/core/v1/resource_quota.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ResourceQuota {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ResourceQuota";
+    const PLURAL_NAME: &'static str = "resourcequotas";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ResourceQuota {

--- a/src/v1_18/api/core/v1/secret.rs
+++ b/src/v1_18/api/core/v1/secret.rs
@@ -498,7 +498,10 @@ impl crate::Resource for Secret {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Secret";
+    const PLURAL_NAME: &'static str = "secrets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Secret {

--- a/src/v1_18/api/core/v1/service.rs
+++ b/src/v1_18/api/core/v1/service.rs
@@ -1181,7 +1181,10 @@ impl crate::Resource for Service {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Service";
+    const PLURAL_NAME: &'static str = "services";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Service {

--- a/src/v1_18/api/core/v1/service_account.rs
+++ b/src/v1_18/api/core/v1/service_account.rs
@@ -495,7 +495,10 @@ impl crate::Resource for ServiceAccount {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ServiceAccount";
+    const PLURAL_NAME: &'static str = "serviceaccounts";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ServiceAccount {

--- a/src/v1_18/api/discovery/v1beta1/endpoint_slice.rs
+++ b/src/v1_18/api/discovery/v1beta1/endpoint_slice.rs
@@ -495,7 +495,10 @@ impl crate::Resource for EndpointSlice {
     const API_VERSION: &'static str = "discovery.k8s.io/v1beta1";
     const GROUP: &'static str = "discovery.k8s.io";
     const KIND: &'static str = "EndpointSlice";
+    const PLURAL_NAME: &'static str = "endpointslices";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for EndpointSlice {

--- a/src/v1_18/api/events/v1beta1/event.rs
+++ b/src/v1_18/api/events/v1beta1/event.rs
@@ -527,7 +527,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "events.k8s.io/v1beta1";
     const GROUP: &'static str = "events.k8s.io";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_18/api/extensions/v1beta1/ingress.rs
+++ b/src/v1_18/api/extensions/v1beta1/ingress.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Ingress {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Ingress";
+    const PLURAL_NAME: &'static str = "ingresses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Ingress {

--- a/src/v1_18/api/flowcontrol/v1alpha1/flow_schema.rs
+++ b/src/v1_18/api/flowcontrol/v1alpha1/flow_schema.rs
@@ -550,7 +550,10 @@ impl crate::Resource for FlowSchema {
     const API_VERSION: &'static str = "flowcontrol.apiserver.k8s.io/v1alpha1";
     const GROUP: &'static str = "flowcontrol.apiserver.k8s.io";
     const KIND: &'static str = "FlowSchema";
+    const PLURAL_NAME: &'static str = "flowschemas";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for FlowSchema {

--- a/src/v1_18/api/flowcontrol/v1alpha1/priority_level_configuration.rs
+++ b/src/v1_18/api/flowcontrol/v1alpha1/priority_level_configuration.rs
@@ -550,7 +550,10 @@ impl crate::Resource for PriorityLevelConfiguration {
     const API_VERSION: &'static str = "flowcontrol.apiserver.k8s.io/v1alpha1";
     const GROUP: &'static str = "flowcontrol.apiserver.k8s.io";
     const KIND: &'static str = "PriorityLevelConfiguration";
+    const PLURAL_NAME: &'static str = "prioritylevelconfigurations";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityLevelConfiguration {

--- a/src/v1_18/api/networking/v1/network_policy.rs
+++ b/src/v1_18/api/networking/v1/network_policy.rs
@@ -489,7 +489,10 @@ impl crate::Resource for NetworkPolicy {
     const API_VERSION: &'static str = "networking.k8s.io/v1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "NetworkPolicy";
+    const PLURAL_NAME: &'static str = "networkpolicies";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for NetworkPolicy {

--- a/src/v1_18/api/networking/v1beta1/ingress.rs
+++ b/src/v1_18/api/networking/v1beta1/ingress.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Ingress {
     const API_VERSION: &'static str = "networking.k8s.io/v1beta1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "Ingress";
+    const PLURAL_NAME: &'static str = "ingresses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Ingress {

--- a/src/v1_18/api/networking/v1beta1/ingress_class.rs
+++ b/src/v1_18/api/networking/v1beta1/ingress_class.rs
@@ -373,7 +373,10 @@ impl crate::Resource for IngressClass {
     const API_VERSION: &'static str = "networking.k8s.io/v1beta1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "IngressClass";
+    const PLURAL_NAME: &'static str = "ingressclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for IngressClass {

--- a/src/v1_18/api/node/v1alpha1/runtime_class.rs
+++ b/src/v1_18/api/node/v1alpha1/runtime_class.rs
@@ -373,7 +373,10 @@ impl crate::Resource for RuntimeClass {
     const API_VERSION: &'static str = "node.k8s.io/v1alpha1";
     const GROUP: &'static str = "node.k8s.io";
     const KIND: &'static str = "RuntimeClass";
+    const PLURAL_NAME: &'static str = "runtimeclasses";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for RuntimeClass {

--- a/src/v1_18/api/node/v1beta1/runtime_class.rs
+++ b/src/v1_18/api/node/v1beta1/runtime_class.rs
@@ -379,7 +379,10 @@ impl crate::Resource for RuntimeClass {
     const API_VERSION: &'static str = "node.k8s.io/v1beta1";
     const GROUP: &'static str = "node.k8s.io";
     const KIND: &'static str = "RuntimeClass";
+    const PLURAL_NAME: &'static str = "runtimeclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for RuntimeClass {

--- a/src/v1_18/api/policy/v1beta1/eviction.rs
+++ b/src/v1_18/api/policy/v1beta1/eviction.rs
@@ -65,7 +65,10 @@ impl crate::Resource for Eviction {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "Eviction";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Eviction {

--- a/src/v1_18/api/policy/v1beta1/pod_disruption_budget.rs
+++ b/src/v1_18/api/policy/v1beta1/pod_disruption_budget.rs
@@ -683,7 +683,10 @@ impl crate::Resource for PodDisruptionBudget {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "PodDisruptionBudget";
+    const PLURAL_NAME: &'static str = "poddisruptionbudgets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodDisruptionBudget {

--- a/src/v1_18/api/policy/v1beta1/pod_security_policy.rs
+++ b/src/v1_18/api/policy/v1beta1/pod_security_policy.rs
@@ -373,7 +373,10 @@ impl crate::Resource for PodSecurityPolicy {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "PodSecurityPolicy";
+    const PLURAL_NAME: &'static str = "podsecuritypolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PodSecurityPolicy {

--- a/src/v1_18/api/rbac/v1/cluster_role.rs
+++ b/src/v1_18/api/rbac/v1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_18/api/rbac/v1/cluster_role_binding.rs
+++ b/src/v1_18/api/rbac/v1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_18/api/rbac/v1/role.rs
+++ b/src/v1_18/api/rbac/v1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_18/api/rbac/v1/role_binding.rs
+++ b/src/v1_18/api/rbac/v1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_18/api/rbac/v1alpha1/cluster_role.rs
+++ b/src/v1_18/api/rbac/v1alpha1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_18/api/rbac/v1alpha1/cluster_role_binding.rs
+++ b/src/v1_18/api/rbac/v1alpha1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_18/api/rbac/v1alpha1/role.rs
+++ b/src/v1_18/api/rbac/v1alpha1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_18/api/rbac/v1alpha1/role_binding.rs
+++ b/src/v1_18/api/rbac/v1alpha1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_18/api/rbac/v1beta1/cluster_role.rs
+++ b/src/v1_18/api/rbac/v1beta1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_18/api/rbac/v1beta1/cluster_role_binding.rs
+++ b/src/v1_18/api/rbac/v1beta1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_18/api/rbac/v1beta1/role.rs
+++ b/src/v1_18/api/rbac/v1beta1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_18/api/rbac/v1beta1/role_binding.rs
+++ b/src/v1_18/api/rbac/v1beta1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_18/api/scheduling/v1/priority_class.rs
+++ b/src/v1_18/api/scheduling/v1/priority_class.rs
@@ -382,7 +382,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_18/api/scheduling/v1alpha1/priority_class.rs
+++ b/src/v1_18/api/scheduling/v1alpha1/priority_class.rs
@@ -382,7 +382,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1alpha1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_18/api/scheduling/v1beta1/priority_class.rs
+++ b/src/v1_18/api/scheduling/v1beta1/priority_class.rs
@@ -382,7 +382,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1beta1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_18/api/settings/v1alpha1/pod_preset.rs
+++ b/src/v1_18/api/settings/v1alpha1/pod_preset.rs
@@ -487,7 +487,10 @@ impl crate::Resource for PodPreset {
     const API_VERSION: &'static str = "settings.k8s.io/v1alpha1";
     const GROUP: &'static str = "settings.k8s.io";
     const KIND: &'static str = "PodPreset";
+    const PLURAL_NAME: &'static str = "podpresets";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodPreset {

--- a/src/v1_18/api/storage/v1/csi_driver.rs
+++ b/src/v1_18/api/storage/v1/csi_driver.rs
@@ -373,7 +373,10 @@ impl crate::Resource for CSIDriver {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSIDriver";
+    const PLURAL_NAME: &'static str = "csidrivers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSIDriver {

--- a/src/v1_18/api/storage/v1/csi_node.rs
+++ b/src/v1_18/api/storage/v1/csi_node.rs
@@ -373,7 +373,10 @@ impl crate::Resource for CSINode {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSINode";
+    const PLURAL_NAME: &'static str = "csinodes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSINode {

--- a/src/v1_18/api/storage/v1/storage_class.rs
+++ b/src/v1_18/api/storage/v1/storage_class.rs
@@ -393,7 +393,10 @@ impl crate::Resource for StorageClass {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "StorageClass";
+    const PLURAL_NAME: &'static str = "storageclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageClass {

--- a/src/v1_18/api/storage/v1/volume_attachment.rs
+++ b/src/v1_18/api/storage/v1/volume_attachment.rs
@@ -552,7 +552,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_18/api/storage/v1alpha1/volume_attachment.rs
+++ b/src/v1_18/api/storage/v1alpha1/volume_attachment.rs
@@ -378,7 +378,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1alpha1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_18/api/storage/v1beta1/csi_driver.rs
+++ b/src/v1_18/api/storage/v1beta1/csi_driver.rs
@@ -373,7 +373,10 @@ impl crate::Resource for CSIDriver {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSIDriver";
+    const PLURAL_NAME: &'static str = "csidrivers";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSIDriver {

--- a/src/v1_18/api/storage/v1beta1/csi_node.rs
+++ b/src/v1_18/api/storage/v1beta1/csi_node.rs
@@ -373,7 +373,10 @@ impl crate::Resource for CSINode {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSINode";
+    const PLURAL_NAME: &'static str = "csinodes";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSINode {

--- a/src/v1_18/api/storage/v1beta1/storage_class.rs
+++ b/src/v1_18/api/storage/v1beta1/storage_class.rs
@@ -393,7 +393,10 @@ impl crate::Resource for StorageClass {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "StorageClass";
+    const PLURAL_NAME: &'static str = "storageclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageClass {

--- a/src/v1_18/api/storage/v1beta1/volume_attachment.rs
+++ b/src/v1_18/api/storage/v1beta1/volume_attachment.rs
@@ -378,7 +378,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_18/apiextensions_apiserver/pkg/apis/apiextensions/v1/custom_resource_definition.rs
+++ b/src/v1_18/apiextensions_apiserver/pkg/apis/apiextensions/v1/custom_resource_definition.rs
@@ -549,7 +549,10 @@ impl crate::Resource for CustomResourceDefinition {
     const API_VERSION: &'static str = "apiextensions.k8s.io/v1";
     const GROUP: &'static str = "apiextensions.k8s.io";
     const KIND: &'static str = "CustomResourceDefinition";
+    const PLURAL_NAME: &'static str = "customresourcedefinitions";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CustomResourceDefinition {

--- a/src/v1_18/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
+++ b/src/v1_18/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
@@ -549,7 +549,10 @@ impl crate::Resource for CustomResourceDefinition {
     const API_VERSION: &'static str = "apiextensions.k8s.io/v1beta1";
     const GROUP: &'static str = "apiextensions.k8s.io";
     const KIND: &'static str = "CustomResourceDefinition";
+    const PLURAL_NAME: &'static str = "customresourcedefinitions";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CustomResourceDefinition {

--- a/src/v1_18/apimachinery/pkg/apis/meta/v1/api_group.rs
+++ b/src/v1_18/apimachinery/pkg/apis/meta/v1/api_group.rs
@@ -20,7 +20,10 @@ impl crate::Resource for APIGroup {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIGroup";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIGroup {

--- a/src/v1_18/apimachinery/pkg/apis/meta/v1/api_group_list.rs
+++ b/src/v1_18/apimachinery/pkg/apis/meta/v1/api_group_list.rs
@@ -11,7 +11,10 @@ impl crate::Resource for APIGroupList {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIGroupList";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIGroupList {

--- a/src/v1_18/apimachinery/pkg/apis/meta/v1/api_resource_list.rs
+++ b/src/v1_18/apimachinery/pkg/apis/meta/v1/api_resource_list.rs
@@ -14,7 +14,10 @@ impl crate::Resource for APIResourceList {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIResourceList";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIResourceList {

--- a/src/v1_18/apimachinery/pkg/apis/meta/v1/api_versions.rs
+++ b/src/v1_18/apimachinery/pkg/apis/meta/v1/api_versions.rs
@@ -14,7 +14,10 @@ impl crate::Resource for APIVersions {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIVersions";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIVersions {

--- a/src/v1_18/apimachinery/pkg/apis/meta/v1/status.rs
+++ b/src/v1_18/apimachinery/pkg/apis/meta/v1/status.rs
@@ -26,7 +26,10 @@ impl crate::Resource for Status {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Status";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Status {

--- a/src/v1_18/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
+++ b/src/v1_18/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
@@ -549,7 +549,10 @@ impl crate::Resource for APIService {
     const API_VERSION: &'static str = "apiregistration.k8s.io/v1";
     const GROUP: &'static str = "apiregistration.k8s.io";
     const KIND: &'static str = "APIService";
+    const PLURAL_NAME: &'static str = "apiservices";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for APIService {

--- a/src/v1_18/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
+++ b/src/v1_18/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
@@ -549,7 +549,10 @@ impl crate::Resource for APIService {
     const API_VERSION: &'static str = "apiregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "apiregistration.k8s.io";
     const KIND: &'static str = "APIService";
+    const PLURAL_NAME: &'static str = "apiservices";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for APIService {

--- a/src/v1_18/list.rs
+++ b/src/v1_18/list.rs
@@ -14,7 +14,10 @@ impl<T> crate::Resource for List<T> where T: crate::ListableResource {
     const API_VERSION: &'static str = <T as crate::Resource>::API_VERSION;
     const GROUP: &'static str = <T as crate::Resource>::GROUP;
     const KIND: &'static str = <T as crate::ListableResource>::LIST_KIND;
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = <T as crate::Resource>::VERSION;
+    const NAMESPACED: bool = <T as crate::Resource>::NAMESPACED;
+    type Scope = <T as crate::Resource>::Scope;
 }
 
 impl<T> crate::Metadata for List<T> where T: crate::ListableResource {

--- a/src/v1_19/api/admissionregistration/v1/mutating_webhook_configuration.rs
+++ b/src/v1_19/api/admissionregistration/v1/mutating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for MutatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "MutatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "mutatingwebhookconfigurations";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for MutatingWebhookConfiguration {

--- a/src/v1_19/api/admissionregistration/v1/validating_webhook_configuration.rs
+++ b/src/v1_19/api/admissionregistration/v1/validating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for ValidatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "ValidatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "validatingwebhookconfigurations";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ValidatingWebhookConfiguration {

--- a/src/v1_19/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
+++ b/src/v1_19/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for MutatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "MutatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "mutatingwebhookconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for MutatingWebhookConfiguration {

--- a/src/v1_19/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
+++ b/src/v1_19/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for ValidatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "ValidatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "validatingwebhookconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ValidatingWebhookConfiguration {

--- a/src/v1_19/api/apps/v1/controller_revision.rs
+++ b/src/v1_19/api/apps/v1/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_19/api/apps/v1/daemon_set.rs
+++ b/src/v1_19/api/apps/v1/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_19/api/apps/v1/deployment.rs
+++ b/src/v1_19/api/apps/v1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_19/api/apps/v1/replica_set.rs
+++ b/src/v1_19/api/apps/v1/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_19/api/apps/v1/stateful_set.rs
+++ b/src/v1_19/api/apps/v1/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_19/api/authentication/v1/token_request.rs
+++ b/src/v1_19/api/authentication/v1/token_request.rs
@@ -65,7 +65,10 @@ impl crate::Resource for TokenRequest {
     const API_VERSION: &'static str = "authentication.k8s.io/v1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenRequest";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenRequest {

--- a/src/v1_19/api/authentication/v1/token_review.rs
+++ b/src/v1_19/api/authentication/v1/token_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for TokenReview {
     const API_VERSION: &'static str = "authentication.k8s.io/v1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenReview";
+    const PLURAL_NAME: &'static str = "tokenreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenReview {

--- a/src/v1_19/api/authentication/v1beta1/token_review.rs
+++ b/src/v1_19/api/authentication/v1beta1/token_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for TokenReview {
     const API_VERSION: &'static str = "authentication.k8s.io/v1beta1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenReview";
+    const PLURAL_NAME: &'static str = "tokenreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenReview {

--- a/src/v1_19/api/authorization/v1/local_subject_access_review.rs
+++ b/src/v1_19/api/authorization/v1/local_subject_access_review.rs
@@ -61,7 +61,10 @@ impl crate::Resource for LocalSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "LocalSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "localsubjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for LocalSubjectAccessReview {

--- a/src/v1_19/api/authorization/v1/self_subject_access_review.rs
+++ b/src/v1_19/api/authorization/v1/self_subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "selfsubjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectAccessReview {

--- a/src/v1_19/api/authorization/v1/self_subject_rules_review.rs
+++ b/src/v1_19/api/authorization/v1/self_subject_rules_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectRulesReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectRulesReview";
+    const PLURAL_NAME: &'static str = "selfsubjectrulesreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectRulesReview {

--- a/src/v1_19/api/authorization/v1/subject_access_review.rs
+++ b/src/v1_19/api/authorization/v1/subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SubjectAccessReview";
+    const PLURAL_NAME: &'static str = "subjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SubjectAccessReview {

--- a/src/v1_19/api/authorization/v1beta1/local_subject_access_review.rs
+++ b/src/v1_19/api/authorization/v1beta1/local_subject_access_review.rs
@@ -61,7 +61,10 @@ impl crate::Resource for LocalSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "LocalSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "localsubjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for LocalSubjectAccessReview {

--- a/src/v1_19/api/authorization/v1beta1/self_subject_access_review.rs
+++ b/src/v1_19/api/authorization/v1beta1/self_subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "selfsubjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectAccessReview {

--- a/src/v1_19/api/authorization/v1beta1/self_subject_rules_review.rs
+++ b/src/v1_19/api/authorization/v1beta1/self_subject_rules_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectRulesReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectRulesReview";
+    const PLURAL_NAME: &'static str = "selfsubjectrulesreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectRulesReview {

--- a/src/v1_19/api/authorization/v1beta1/subject_access_review.rs
+++ b/src/v1_19/api/authorization/v1beta1/subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SubjectAccessReview";
+    const PLURAL_NAME: &'static str = "subjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SubjectAccessReview {

--- a/src/v1_19/api/autoscaling/v1/horizontal_pod_autoscaler.rs
+++ b/src/v1_19/api/autoscaling/v1/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_19/api/autoscaling/v1/scale.rs
+++ b/src/v1_19/api/autoscaling/v1/scale.rs
@@ -789,7 +789,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "autoscaling/v1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_19/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
+++ b/src/v1_19/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v2beta1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v2beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_19/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
+++ b/src/v1_19/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v2beta2";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v2beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_19/api/batch/v1/job.rs
+++ b/src/v1_19/api/batch/v1/job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Job {
     const API_VERSION: &'static str = "batch/v1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "Job";
+    const PLURAL_NAME: &'static str = "jobs";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Job {

--- a/src/v1_19/api/batch/v1beta1/cron_job.rs
+++ b/src/v1_19/api/batch/v1beta1/cron_job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for CronJob {
     const API_VERSION: &'static str = "batch/v1beta1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "CronJob";
+    const PLURAL_NAME: &'static str = "cronjobs";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CronJob {

--- a/src/v1_19/api/batch/v2alpha1/cron_job.rs
+++ b/src/v1_19/api/batch/v2alpha1/cron_job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for CronJob {
     const API_VERSION: &'static str = "batch/v2alpha1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "CronJob";
+    const PLURAL_NAME: &'static str = "cronjobs";
     const VERSION: &'static str = "v2alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CronJob {

--- a/src/v1_19/api/certificates/v1/certificate_signing_request.rs
+++ b/src/v1_19/api/certificates/v1/certificate_signing_request.rs
@@ -729,7 +729,10 @@ impl crate::Resource for CertificateSigningRequest {
     const API_VERSION: &'static str = "certificates.k8s.io/v1";
     const GROUP: &'static str = "certificates.k8s.io";
     const KIND: &'static str = "CertificateSigningRequest";
+    const PLURAL_NAME: &'static str = "certificatesigningrequests";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CertificateSigningRequest {

--- a/src/v1_19/api/certificates/v1beta1/certificate_signing_request.rs
+++ b/src/v1_19/api/certificates/v1beta1/certificate_signing_request.rs
@@ -723,7 +723,10 @@ impl crate::Resource for CertificateSigningRequest {
     const API_VERSION: &'static str = "certificates.k8s.io/v1beta1";
     const GROUP: &'static str = "certificates.k8s.io";
     const KIND: &'static str = "CertificateSigningRequest";
+    const PLURAL_NAME: &'static str = "certificatesigningrequests";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CertificateSigningRequest {

--- a/src/v1_19/api/coordination/v1/lease.rs
+++ b/src/v1_19/api/coordination/v1/lease.rs
@@ -489,7 +489,10 @@ impl crate::Resource for Lease {
     const API_VERSION: &'static str = "coordination.k8s.io/v1";
     const GROUP: &'static str = "coordination.k8s.io";
     const KIND: &'static str = "Lease";
+    const PLURAL_NAME: &'static str = "leases";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Lease {

--- a/src/v1_19/api/coordination/v1beta1/lease.rs
+++ b/src/v1_19/api/coordination/v1beta1/lease.rs
@@ -489,7 +489,10 @@ impl crate::Resource for Lease {
     const API_VERSION: &'static str = "coordination.k8s.io/v1beta1";
     const GROUP: &'static str = "coordination.k8s.io";
     const KIND: &'static str = "Lease";
+    const PLURAL_NAME: &'static str = "leases";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Lease {

--- a/src/v1_19/api/core/v1/binding.rs
+++ b/src/v1_19/api/core/v1/binding.rs
@@ -106,7 +106,10 @@ impl crate::Resource for Binding {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Binding";
+    const PLURAL_NAME: &'static str = "bindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for Binding {

--- a/src/v1_19/api/core/v1/component_status.rs
+++ b/src/v1_19/api/core/v1/component_status.rs
@@ -170,7 +170,10 @@ impl crate::Resource for ComponentStatus {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ComponentStatus";
+    const PLURAL_NAME: &'static str = "componentstatuses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ComponentStatus {

--- a/src/v1_19/api/core/v1/config_map.rs
+++ b/src/v1_19/api/core/v1/config_map.rs
@@ -495,7 +495,10 @@ impl crate::Resource for ConfigMap {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ConfigMap";
+    const PLURAL_NAME: &'static str = "configmaps";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ConfigMap {

--- a/src/v1_19/api/core/v1/endpoints.rs
+++ b/src/v1_19/api/core/v1/endpoints.rs
@@ -500,7 +500,10 @@ impl crate::Resource for Endpoints {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Endpoints";
+    const PLURAL_NAME: &'static str = "endpoints";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Endpoints {

--- a/src/v1_19/api/core/v1/event.rs
+++ b/src/v1_19/api/core/v1/event.rs
@@ -528,7 +528,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_19/api/core/v1/limit_range.rs
+++ b/src/v1_19/api/core/v1/limit_range.rs
@@ -489,7 +489,10 @@ impl crate::Resource for LimitRange {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "LimitRange";
+    const PLURAL_NAME: &'static str = "limitranges";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for LimitRange {

--- a/src/v1_19/api/core/v1/namespace.rs
+++ b/src/v1_19/api/core/v1/namespace.rs
@@ -555,7 +555,10 @@ impl crate::Resource for Namespace {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Namespace";
+    const PLURAL_NAME: &'static str = "namespaces";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for Namespace {

--- a/src/v1_19/api/core/v1/node.rs
+++ b/src/v1_19/api/core/v1/node.rs
@@ -1030,7 +1030,10 @@ impl crate::Resource for Node {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Node";
+    const PLURAL_NAME: &'static str = "nodes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for Node {

--- a/src/v1_19/api/core/v1/persistent_volume.rs
+++ b/src/v1_19/api/core/v1/persistent_volume.rs
@@ -550,7 +550,10 @@ impl crate::Resource for PersistentVolume {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PersistentVolume";
+    const PLURAL_NAME: &'static str = "persistentvolumes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PersistentVolume {

--- a/src/v1_19/api/core/v1/persistent_volume_claim.rs
+++ b/src/v1_19/api/core/v1/persistent_volume_claim.rs
@@ -684,7 +684,10 @@ impl crate::Resource for PersistentVolumeClaim {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PersistentVolumeClaim";
+    const PLURAL_NAME: &'static str = "persistentvolumeclaims";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PersistentVolumeClaim {

--- a/src/v1_19/api/core/v1/pod.rs
+++ b/src/v1_19/api/core/v1/pod.rs
@@ -1790,7 +1790,10 @@ impl crate::Resource for Pod {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Pod";
+    const PLURAL_NAME: &'static str = "pods";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Pod {

--- a/src/v1_19/api/core/v1/pod_template.rs
+++ b/src/v1_19/api/core/v1/pod_template.rs
@@ -489,7 +489,10 @@ impl crate::Resource for PodTemplate {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PodTemplate";
+    const PLURAL_NAME: &'static str = "podtemplates";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodTemplate {

--- a/src/v1_19/api/core/v1/replication_controller.rs
+++ b/src/v1_19/api/core/v1/replication_controller.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicationController {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ReplicationController";
+    const PLURAL_NAME: &'static str = "replicationcontrollers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicationController {

--- a/src/v1_19/api/core/v1/resource_quota.rs
+++ b/src/v1_19/api/core/v1/resource_quota.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ResourceQuota {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ResourceQuota";
+    const PLURAL_NAME: &'static str = "resourcequotas";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ResourceQuota {

--- a/src/v1_19/api/core/v1/secret.rs
+++ b/src/v1_19/api/core/v1/secret.rs
@@ -498,7 +498,10 @@ impl crate::Resource for Secret {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Secret";
+    const PLURAL_NAME: &'static str = "secrets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Secret {

--- a/src/v1_19/api/core/v1/service.rs
+++ b/src/v1_19/api/core/v1/service.rs
@@ -1181,7 +1181,10 @@ impl crate::Resource for Service {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Service";
+    const PLURAL_NAME: &'static str = "services";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Service {

--- a/src/v1_19/api/core/v1/service_account.rs
+++ b/src/v1_19/api/core/v1/service_account.rs
@@ -495,7 +495,10 @@ impl crate::Resource for ServiceAccount {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ServiceAccount";
+    const PLURAL_NAME: &'static str = "serviceaccounts";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ServiceAccount {

--- a/src/v1_19/api/discovery/v1beta1/endpoint_slice.rs
+++ b/src/v1_19/api/discovery/v1beta1/endpoint_slice.rs
@@ -495,7 +495,10 @@ impl crate::Resource for EndpointSlice {
     const API_VERSION: &'static str = "discovery.k8s.io/v1beta1";
     const GROUP: &'static str = "discovery.k8s.io";
     const KIND: &'static str = "EndpointSlice";
+    const PLURAL_NAME: &'static str = "endpointslices";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for EndpointSlice {

--- a/src/v1_19/api/events/v1/event.rs
+++ b/src/v1_19/api/events/v1/event.rs
@@ -527,7 +527,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "events.k8s.io/v1";
     const GROUP: &'static str = "events.k8s.io";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_19/api/events/v1beta1/event.rs
+++ b/src/v1_19/api/events/v1beta1/event.rs
@@ -527,7 +527,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "events.k8s.io/v1beta1";
     const GROUP: &'static str = "events.k8s.io";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_19/api/extensions/v1beta1/ingress.rs
+++ b/src/v1_19/api/extensions/v1beta1/ingress.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Ingress {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Ingress";
+    const PLURAL_NAME: &'static str = "ingresses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Ingress {

--- a/src/v1_19/api/flowcontrol/v1alpha1/flow_schema.rs
+++ b/src/v1_19/api/flowcontrol/v1alpha1/flow_schema.rs
@@ -550,7 +550,10 @@ impl crate::Resource for FlowSchema {
     const API_VERSION: &'static str = "flowcontrol.apiserver.k8s.io/v1alpha1";
     const GROUP: &'static str = "flowcontrol.apiserver.k8s.io";
     const KIND: &'static str = "FlowSchema";
+    const PLURAL_NAME: &'static str = "flowschemas";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for FlowSchema {

--- a/src/v1_19/api/flowcontrol/v1alpha1/priority_level_configuration.rs
+++ b/src/v1_19/api/flowcontrol/v1alpha1/priority_level_configuration.rs
@@ -550,7 +550,10 @@ impl crate::Resource for PriorityLevelConfiguration {
     const API_VERSION: &'static str = "flowcontrol.apiserver.k8s.io/v1alpha1";
     const GROUP: &'static str = "flowcontrol.apiserver.k8s.io";
     const KIND: &'static str = "PriorityLevelConfiguration";
+    const PLURAL_NAME: &'static str = "prioritylevelconfigurations";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityLevelConfiguration {

--- a/src/v1_19/api/networking/v1/ingress.rs
+++ b/src/v1_19/api/networking/v1/ingress.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Ingress {
     const API_VERSION: &'static str = "networking.k8s.io/v1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "Ingress";
+    const PLURAL_NAME: &'static str = "ingresses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Ingress {

--- a/src/v1_19/api/networking/v1/ingress_class.rs
+++ b/src/v1_19/api/networking/v1/ingress_class.rs
@@ -373,7 +373,10 @@ impl crate::Resource for IngressClass {
     const API_VERSION: &'static str = "networking.k8s.io/v1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "IngressClass";
+    const PLURAL_NAME: &'static str = "ingressclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for IngressClass {

--- a/src/v1_19/api/networking/v1/network_policy.rs
+++ b/src/v1_19/api/networking/v1/network_policy.rs
@@ -489,7 +489,10 @@ impl crate::Resource for NetworkPolicy {
     const API_VERSION: &'static str = "networking.k8s.io/v1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "NetworkPolicy";
+    const PLURAL_NAME: &'static str = "networkpolicies";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for NetworkPolicy {

--- a/src/v1_19/api/networking/v1beta1/ingress.rs
+++ b/src/v1_19/api/networking/v1beta1/ingress.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Ingress {
     const API_VERSION: &'static str = "networking.k8s.io/v1beta1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "Ingress";
+    const PLURAL_NAME: &'static str = "ingresses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Ingress {

--- a/src/v1_19/api/networking/v1beta1/ingress_class.rs
+++ b/src/v1_19/api/networking/v1beta1/ingress_class.rs
@@ -373,7 +373,10 @@ impl crate::Resource for IngressClass {
     const API_VERSION: &'static str = "networking.k8s.io/v1beta1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "IngressClass";
+    const PLURAL_NAME: &'static str = "ingressclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for IngressClass {

--- a/src/v1_19/api/node/v1alpha1/runtime_class.rs
+++ b/src/v1_19/api/node/v1alpha1/runtime_class.rs
@@ -373,7 +373,10 @@ impl crate::Resource for RuntimeClass {
     const API_VERSION: &'static str = "node.k8s.io/v1alpha1";
     const GROUP: &'static str = "node.k8s.io";
     const KIND: &'static str = "RuntimeClass";
+    const PLURAL_NAME: &'static str = "runtimeclasses";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for RuntimeClass {

--- a/src/v1_19/api/node/v1beta1/runtime_class.rs
+++ b/src/v1_19/api/node/v1beta1/runtime_class.rs
@@ -379,7 +379,10 @@ impl crate::Resource for RuntimeClass {
     const API_VERSION: &'static str = "node.k8s.io/v1beta1";
     const GROUP: &'static str = "node.k8s.io";
     const KIND: &'static str = "RuntimeClass";
+    const PLURAL_NAME: &'static str = "runtimeclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for RuntimeClass {

--- a/src/v1_19/api/policy/v1beta1/eviction.rs
+++ b/src/v1_19/api/policy/v1beta1/eviction.rs
@@ -65,7 +65,10 @@ impl crate::Resource for Eviction {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "Eviction";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Eviction {

--- a/src/v1_19/api/policy/v1beta1/pod_disruption_budget.rs
+++ b/src/v1_19/api/policy/v1beta1/pod_disruption_budget.rs
@@ -683,7 +683,10 @@ impl crate::Resource for PodDisruptionBudget {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "PodDisruptionBudget";
+    const PLURAL_NAME: &'static str = "poddisruptionbudgets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodDisruptionBudget {

--- a/src/v1_19/api/policy/v1beta1/pod_security_policy.rs
+++ b/src/v1_19/api/policy/v1beta1/pod_security_policy.rs
@@ -373,7 +373,10 @@ impl crate::Resource for PodSecurityPolicy {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "PodSecurityPolicy";
+    const PLURAL_NAME: &'static str = "podsecuritypolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PodSecurityPolicy {

--- a/src/v1_19/api/rbac/v1/cluster_role.rs
+++ b/src/v1_19/api/rbac/v1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_19/api/rbac/v1/cluster_role_binding.rs
+++ b/src/v1_19/api/rbac/v1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_19/api/rbac/v1/role.rs
+++ b/src/v1_19/api/rbac/v1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_19/api/rbac/v1/role_binding.rs
+++ b/src/v1_19/api/rbac/v1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_19/api/rbac/v1alpha1/cluster_role.rs
+++ b/src/v1_19/api/rbac/v1alpha1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_19/api/rbac/v1alpha1/cluster_role_binding.rs
+++ b/src/v1_19/api/rbac/v1alpha1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_19/api/rbac/v1alpha1/role.rs
+++ b/src/v1_19/api/rbac/v1alpha1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_19/api/rbac/v1alpha1/role_binding.rs
+++ b/src/v1_19/api/rbac/v1alpha1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_19/api/rbac/v1beta1/cluster_role.rs
+++ b/src/v1_19/api/rbac/v1beta1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_19/api/rbac/v1beta1/cluster_role_binding.rs
+++ b/src/v1_19/api/rbac/v1beta1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_19/api/rbac/v1beta1/role.rs
+++ b/src/v1_19/api/rbac/v1beta1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_19/api/rbac/v1beta1/role_binding.rs
+++ b/src/v1_19/api/rbac/v1beta1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_19/api/scheduling/v1/priority_class.rs
+++ b/src/v1_19/api/scheduling/v1/priority_class.rs
@@ -382,7 +382,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_19/api/scheduling/v1alpha1/priority_class.rs
+++ b/src/v1_19/api/scheduling/v1alpha1/priority_class.rs
@@ -382,7 +382,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1alpha1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_19/api/scheduling/v1beta1/priority_class.rs
+++ b/src/v1_19/api/scheduling/v1beta1/priority_class.rs
@@ -382,7 +382,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1beta1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_19/api/settings/v1alpha1/pod_preset.rs
+++ b/src/v1_19/api/settings/v1alpha1/pod_preset.rs
@@ -487,7 +487,10 @@ impl crate::Resource for PodPreset {
     const API_VERSION: &'static str = "settings.k8s.io/v1alpha1";
     const GROUP: &'static str = "settings.k8s.io";
     const KIND: &'static str = "PodPreset";
+    const PLURAL_NAME: &'static str = "podpresets";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodPreset {

--- a/src/v1_19/api/storage/v1/csi_driver.rs
+++ b/src/v1_19/api/storage/v1/csi_driver.rs
@@ -373,7 +373,10 @@ impl crate::Resource for CSIDriver {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSIDriver";
+    const PLURAL_NAME: &'static str = "csidrivers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSIDriver {

--- a/src/v1_19/api/storage/v1/csi_node.rs
+++ b/src/v1_19/api/storage/v1/csi_node.rs
@@ -373,7 +373,10 @@ impl crate::Resource for CSINode {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSINode";
+    const PLURAL_NAME: &'static str = "csinodes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSINode {

--- a/src/v1_19/api/storage/v1/storage_class.rs
+++ b/src/v1_19/api/storage/v1/storage_class.rs
@@ -393,7 +393,10 @@ impl crate::Resource for StorageClass {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "StorageClass";
+    const PLURAL_NAME: &'static str = "storageclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageClass {

--- a/src/v1_19/api/storage/v1/volume_attachment.rs
+++ b/src/v1_19/api/storage/v1/volume_attachment.rs
@@ -552,7 +552,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_19/api/storage/v1alpha1/volume_attachment.rs
+++ b/src/v1_19/api/storage/v1alpha1/volume_attachment.rs
@@ -378,7 +378,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1alpha1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_19/api/storage/v1beta1/csi_driver.rs
+++ b/src/v1_19/api/storage/v1beta1/csi_driver.rs
@@ -373,7 +373,10 @@ impl crate::Resource for CSIDriver {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSIDriver";
+    const PLURAL_NAME: &'static str = "csidrivers";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSIDriver {

--- a/src/v1_19/api/storage/v1beta1/csi_node.rs
+++ b/src/v1_19/api/storage/v1beta1/csi_node.rs
@@ -373,7 +373,10 @@ impl crate::Resource for CSINode {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSINode";
+    const PLURAL_NAME: &'static str = "csinodes";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSINode {

--- a/src/v1_19/api/storage/v1beta1/storage_class.rs
+++ b/src/v1_19/api/storage/v1beta1/storage_class.rs
@@ -393,7 +393,10 @@ impl crate::Resource for StorageClass {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "StorageClass";
+    const PLURAL_NAME: &'static str = "storageclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageClass {

--- a/src/v1_19/api/storage/v1beta1/volume_attachment.rs
+++ b/src/v1_19/api/storage/v1beta1/volume_attachment.rs
@@ -378,7 +378,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_19/apiextensions_apiserver/pkg/apis/apiextensions/v1/custom_resource_definition.rs
+++ b/src/v1_19/apiextensions_apiserver/pkg/apis/apiextensions/v1/custom_resource_definition.rs
@@ -549,7 +549,10 @@ impl crate::Resource for CustomResourceDefinition {
     const API_VERSION: &'static str = "apiextensions.k8s.io/v1";
     const GROUP: &'static str = "apiextensions.k8s.io";
     const KIND: &'static str = "CustomResourceDefinition";
+    const PLURAL_NAME: &'static str = "customresourcedefinitions";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CustomResourceDefinition {

--- a/src/v1_19/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
+++ b/src/v1_19/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
@@ -549,7 +549,10 @@ impl crate::Resource for CustomResourceDefinition {
     const API_VERSION: &'static str = "apiextensions.k8s.io/v1beta1";
     const GROUP: &'static str = "apiextensions.k8s.io";
     const KIND: &'static str = "CustomResourceDefinition";
+    const PLURAL_NAME: &'static str = "customresourcedefinitions";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CustomResourceDefinition {

--- a/src/v1_19/apimachinery/pkg/apis/meta/v1/api_group.rs
+++ b/src/v1_19/apimachinery/pkg/apis/meta/v1/api_group.rs
@@ -20,7 +20,10 @@ impl crate::Resource for APIGroup {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIGroup";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIGroup {

--- a/src/v1_19/apimachinery/pkg/apis/meta/v1/api_group_list.rs
+++ b/src/v1_19/apimachinery/pkg/apis/meta/v1/api_group_list.rs
@@ -11,7 +11,10 @@ impl crate::Resource for APIGroupList {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIGroupList";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIGroupList {

--- a/src/v1_19/apimachinery/pkg/apis/meta/v1/api_resource_list.rs
+++ b/src/v1_19/apimachinery/pkg/apis/meta/v1/api_resource_list.rs
@@ -14,7 +14,10 @@ impl crate::Resource for APIResourceList {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIResourceList";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIResourceList {

--- a/src/v1_19/apimachinery/pkg/apis/meta/v1/api_versions.rs
+++ b/src/v1_19/apimachinery/pkg/apis/meta/v1/api_versions.rs
@@ -14,7 +14,10 @@ impl crate::Resource for APIVersions {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIVersions";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIVersions {

--- a/src/v1_19/apimachinery/pkg/apis/meta/v1/status.rs
+++ b/src/v1_19/apimachinery/pkg/apis/meta/v1/status.rs
@@ -26,7 +26,10 @@ impl crate::Resource for Status {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Status";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Status {

--- a/src/v1_19/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
+++ b/src/v1_19/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
@@ -549,7 +549,10 @@ impl crate::Resource for APIService {
     const API_VERSION: &'static str = "apiregistration.k8s.io/v1";
     const GROUP: &'static str = "apiregistration.k8s.io";
     const KIND: &'static str = "APIService";
+    const PLURAL_NAME: &'static str = "apiservices";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for APIService {

--- a/src/v1_19/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
+++ b/src/v1_19/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
@@ -549,7 +549,10 @@ impl crate::Resource for APIService {
     const API_VERSION: &'static str = "apiregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "apiregistration.k8s.io";
     const KIND: &'static str = "APIService";
+    const PLURAL_NAME: &'static str = "apiservices";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for APIService {

--- a/src/v1_19/list.rs
+++ b/src/v1_19/list.rs
@@ -14,7 +14,10 @@ impl<T> crate::Resource for List<T> where T: crate::ListableResource {
     const API_VERSION: &'static str = <T as crate::Resource>::API_VERSION;
     const GROUP: &'static str = <T as crate::Resource>::GROUP;
     const KIND: &'static str = <T as crate::ListableResource>::LIST_KIND;
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = <T as crate::Resource>::VERSION;
+    const NAMESPACED: bool = <T as crate::Resource>::NAMESPACED;
+    type Scope = <T as crate::Resource>::Scope;
 }
 
 impl<T> crate::Metadata for List<T> where T: crate::ListableResource {

--- a/src/v1_20/api/admissionregistration/v1/mutating_webhook_configuration.rs
+++ b/src/v1_20/api/admissionregistration/v1/mutating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for MutatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "MutatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "mutatingwebhookconfigurations";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for MutatingWebhookConfiguration {

--- a/src/v1_20/api/admissionregistration/v1/validating_webhook_configuration.rs
+++ b/src/v1_20/api/admissionregistration/v1/validating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for ValidatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "ValidatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "validatingwebhookconfigurations";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ValidatingWebhookConfiguration {

--- a/src/v1_20/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
+++ b/src/v1_20/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for MutatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "MutatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "mutatingwebhookconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for MutatingWebhookConfiguration {

--- a/src/v1_20/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
+++ b/src/v1_20/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
@@ -373,7 +373,10 @@ impl crate::Resource for ValidatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "ValidatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "validatingwebhookconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ValidatingWebhookConfiguration {

--- a/src/v1_20/api/apiserverinternal/v1alpha1/storage_version.rs
+++ b/src/v1_20/api/apiserverinternal/v1alpha1/storage_version.rs
@@ -551,7 +551,10 @@ impl crate::Resource for StorageVersion {
     const API_VERSION: &'static str = "internal.apiserver.k8s.io/v1alpha1";
     const GROUP: &'static str = "internal.apiserver.k8s.io";
     const KIND: &'static str = "StorageVersion";
+    const PLURAL_NAME: &'static str = "storageversions";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageVersion {

--- a/src/v1_20/api/apps/v1/controller_revision.rs
+++ b/src/v1_20/api/apps/v1/controller_revision.rs
@@ -492,7 +492,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_20/api/apps/v1/daemon_set.rs
+++ b/src/v1_20/api/apps/v1/daemon_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_20/api/apps/v1/deployment.rs
+++ b/src/v1_20/api/apps/v1/deployment.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_20/api/apps/v1/replica_set.rs
+++ b/src/v1_20/api/apps/v1/replica_set.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_20/api/apps/v1/stateful_set.rs
+++ b/src/v1_20/api/apps/v1/stateful_set.rs
@@ -686,7 +686,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_20/api/authentication/v1/token_request.rs
+++ b/src/v1_20/api/authentication/v1/token_request.rs
@@ -65,7 +65,10 @@ impl crate::Resource for TokenRequest {
     const API_VERSION: &'static str = "authentication.k8s.io/v1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenRequest";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenRequest {

--- a/src/v1_20/api/authentication/v1/token_review.rs
+++ b/src/v1_20/api/authentication/v1/token_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for TokenReview {
     const API_VERSION: &'static str = "authentication.k8s.io/v1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenReview";
+    const PLURAL_NAME: &'static str = "tokenreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenReview {

--- a/src/v1_20/api/authentication/v1beta1/token_review.rs
+++ b/src/v1_20/api/authentication/v1beta1/token_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for TokenReview {
     const API_VERSION: &'static str = "authentication.k8s.io/v1beta1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenReview";
+    const PLURAL_NAME: &'static str = "tokenreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenReview {

--- a/src/v1_20/api/authorization/v1/local_subject_access_review.rs
+++ b/src/v1_20/api/authorization/v1/local_subject_access_review.rs
@@ -61,7 +61,10 @@ impl crate::Resource for LocalSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "LocalSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "localsubjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for LocalSubjectAccessReview {

--- a/src/v1_20/api/authorization/v1/self_subject_access_review.rs
+++ b/src/v1_20/api/authorization/v1/self_subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "selfsubjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectAccessReview {

--- a/src/v1_20/api/authorization/v1/self_subject_rules_review.rs
+++ b/src/v1_20/api/authorization/v1/self_subject_rules_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectRulesReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectRulesReview";
+    const PLURAL_NAME: &'static str = "selfsubjectrulesreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectRulesReview {

--- a/src/v1_20/api/authorization/v1/subject_access_review.rs
+++ b/src/v1_20/api/authorization/v1/subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SubjectAccessReview";
+    const PLURAL_NAME: &'static str = "subjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SubjectAccessReview {

--- a/src/v1_20/api/authorization/v1beta1/local_subject_access_review.rs
+++ b/src/v1_20/api/authorization/v1beta1/local_subject_access_review.rs
@@ -61,7 +61,10 @@ impl crate::Resource for LocalSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "LocalSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "localsubjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for LocalSubjectAccessReview {

--- a/src/v1_20/api/authorization/v1beta1/self_subject_access_review.rs
+++ b/src/v1_20/api/authorization/v1beta1/self_subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "selfsubjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectAccessReview {

--- a/src/v1_20/api/authorization/v1beta1/self_subject_rules_review.rs
+++ b/src/v1_20/api/authorization/v1beta1/self_subject_rules_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectRulesReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectRulesReview";
+    const PLURAL_NAME: &'static str = "selfsubjectrulesreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectRulesReview {

--- a/src/v1_20/api/authorization/v1beta1/subject_access_review.rs
+++ b/src/v1_20/api/authorization/v1beta1/subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SubjectAccessReview";
+    const PLURAL_NAME: &'static str = "subjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SubjectAccessReview {

--- a/src/v1_20/api/autoscaling/v1/horizontal_pod_autoscaler.rs
+++ b/src/v1_20/api/autoscaling/v1/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_20/api/autoscaling/v1/scale.rs
+++ b/src/v1_20/api/autoscaling/v1/scale.rs
@@ -789,7 +789,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "autoscaling/v1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_20/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
+++ b/src/v1_20/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v2beta1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v2beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_20/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
+++ b/src/v1_20/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
@@ -684,7 +684,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v2beta2";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v2beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_20/api/batch/v1/job.rs
+++ b/src/v1_20/api/batch/v1/job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Job {
     const API_VERSION: &'static str = "batch/v1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "Job";
+    const PLURAL_NAME: &'static str = "jobs";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Job {

--- a/src/v1_20/api/batch/v1beta1/cron_job.rs
+++ b/src/v1_20/api/batch/v1beta1/cron_job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for CronJob {
     const API_VERSION: &'static str = "batch/v1beta1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "CronJob";
+    const PLURAL_NAME: &'static str = "cronjobs";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CronJob {

--- a/src/v1_20/api/batch/v2alpha1/cron_job.rs
+++ b/src/v1_20/api/batch/v2alpha1/cron_job.rs
@@ -684,7 +684,10 @@ impl crate::Resource for CronJob {
     const API_VERSION: &'static str = "batch/v2alpha1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "CronJob";
+    const PLURAL_NAME: &'static str = "cronjobs";
     const VERSION: &'static str = "v2alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CronJob {

--- a/src/v1_20/api/certificates/v1/certificate_signing_request.rs
+++ b/src/v1_20/api/certificates/v1/certificate_signing_request.rs
@@ -729,7 +729,10 @@ impl crate::Resource for CertificateSigningRequest {
     const API_VERSION: &'static str = "certificates.k8s.io/v1";
     const GROUP: &'static str = "certificates.k8s.io";
     const KIND: &'static str = "CertificateSigningRequest";
+    const PLURAL_NAME: &'static str = "certificatesigningrequests";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CertificateSigningRequest {

--- a/src/v1_20/api/certificates/v1beta1/certificate_signing_request.rs
+++ b/src/v1_20/api/certificates/v1beta1/certificate_signing_request.rs
@@ -723,7 +723,10 @@ impl crate::Resource for CertificateSigningRequest {
     const API_VERSION: &'static str = "certificates.k8s.io/v1beta1";
     const GROUP: &'static str = "certificates.k8s.io";
     const KIND: &'static str = "CertificateSigningRequest";
+    const PLURAL_NAME: &'static str = "certificatesigningrequests";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CertificateSigningRequest {

--- a/src/v1_20/api/coordination/v1/lease.rs
+++ b/src/v1_20/api/coordination/v1/lease.rs
@@ -489,7 +489,10 @@ impl crate::Resource for Lease {
     const API_VERSION: &'static str = "coordination.k8s.io/v1";
     const GROUP: &'static str = "coordination.k8s.io";
     const KIND: &'static str = "Lease";
+    const PLURAL_NAME: &'static str = "leases";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Lease {

--- a/src/v1_20/api/coordination/v1beta1/lease.rs
+++ b/src/v1_20/api/coordination/v1beta1/lease.rs
@@ -489,7 +489,10 @@ impl crate::Resource for Lease {
     const API_VERSION: &'static str = "coordination.k8s.io/v1beta1";
     const GROUP: &'static str = "coordination.k8s.io";
     const KIND: &'static str = "Lease";
+    const PLURAL_NAME: &'static str = "leases";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Lease {

--- a/src/v1_20/api/core/v1/binding.rs
+++ b/src/v1_20/api/core/v1/binding.rs
@@ -106,7 +106,10 @@ impl crate::Resource for Binding {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Binding";
+    const PLURAL_NAME: &'static str = "bindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for Binding {

--- a/src/v1_20/api/core/v1/component_status.rs
+++ b/src/v1_20/api/core/v1/component_status.rs
@@ -170,7 +170,10 @@ impl crate::Resource for ComponentStatus {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ComponentStatus";
+    const PLURAL_NAME: &'static str = "componentstatuses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ComponentStatus {

--- a/src/v1_20/api/core/v1/config_map.rs
+++ b/src/v1_20/api/core/v1/config_map.rs
@@ -495,7 +495,10 @@ impl crate::Resource for ConfigMap {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ConfigMap";
+    const PLURAL_NAME: &'static str = "configmaps";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ConfigMap {

--- a/src/v1_20/api/core/v1/endpoints.rs
+++ b/src/v1_20/api/core/v1/endpoints.rs
@@ -500,7 +500,10 @@ impl crate::Resource for Endpoints {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Endpoints";
+    const PLURAL_NAME: &'static str = "endpoints";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Endpoints {

--- a/src/v1_20/api/core/v1/event.rs
+++ b/src/v1_20/api/core/v1/event.rs
@@ -528,7 +528,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_20/api/core/v1/limit_range.rs
+++ b/src/v1_20/api/core/v1/limit_range.rs
@@ -489,7 +489,10 @@ impl crate::Resource for LimitRange {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "LimitRange";
+    const PLURAL_NAME: &'static str = "limitranges";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for LimitRange {

--- a/src/v1_20/api/core/v1/namespace.rs
+++ b/src/v1_20/api/core/v1/namespace.rs
@@ -555,7 +555,10 @@ impl crate::Resource for Namespace {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Namespace";
+    const PLURAL_NAME: &'static str = "namespaces";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for Namespace {

--- a/src/v1_20/api/core/v1/node.rs
+++ b/src/v1_20/api/core/v1/node.rs
@@ -1030,7 +1030,10 @@ impl crate::Resource for Node {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Node";
+    const PLURAL_NAME: &'static str = "nodes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for Node {

--- a/src/v1_20/api/core/v1/persistent_volume.rs
+++ b/src/v1_20/api/core/v1/persistent_volume.rs
@@ -550,7 +550,10 @@ impl crate::Resource for PersistentVolume {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PersistentVolume";
+    const PLURAL_NAME: &'static str = "persistentvolumes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PersistentVolume {

--- a/src/v1_20/api/core/v1/persistent_volume_claim.rs
+++ b/src/v1_20/api/core/v1/persistent_volume_claim.rs
@@ -684,7 +684,10 @@ impl crate::Resource for PersistentVolumeClaim {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PersistentVolumeClaim";
+    const PLURAL_NAME: &'static str = "persistentvolumeclaims";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PersistentVolumeClaim {

--- a/src/v1_20/api/core/v1/pod.rs
+++ b/src/v1_20/api/core/v1/pod.rs
@@ -1790,7 +1790,10 @@ impl crate::Resource for Pod {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Pod";
+    const PLURAL_NAME: &'static str = "pods";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Pod {

--- a/src/v1_20/api/core/v1/pod_template.rs
+++ b/src/v1_20/api/core/v1/pod_template.rs
@@ -489,7 +489,10 @@ impl crate::Resource for PodTemplate {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PodTemplate";
+    const PLURAL_NAME: &'static str = "podtemplates";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodTemplate {

--- a/src/v1_20/api/core/v1/replication_controller.rs
+++ b/src/v1_20/api/core/v1/replication_controller.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ReplicationController {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ReplicationController";
+    const PLURAL_NAME: &'static str = "replicationcontrollers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicationController {

--- a/src/v1_20/api/core/v1/resource_quota.rs
+++ b/src/v1_20/api/core/v1/resource_quota.rs
@@ -684,7 +684,10 @@ impl crate::Resource for ResourceQuota {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ResourceQuota";
+    const PLURAL_NAME: &'static str = "resourcequotas";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ResourceQuota {

--- a/src/v1_20/api/core/v1/secret.rs
+++ b/src/v1_20/api/core/v1/secret.rs
@@ -498,7 +498,10 @@ impl crate::Resource for Secret {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Secret";
+    const PLURAL_NAME: &'static str = "secrets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Secret {

--- a/src/v1_20/api/core/v1/service.rs
+++ b/src/v1_20/api/core/v1/service.rs
@@ -1181,7 +1181,10 @@ impl crate::Resource for Service {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Service";
+    const PLURAL_NAME: &'static str = "services";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Service {

--- a/src/v1_20/api/core/v1/service_account.rs
+++ b/src/v1_20/api/core/v1/service_account.rs
@@ -495,7 +495,10 @@ impl crate::Resource for ServiceAccount {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ServiceAccount";
+    const PLURAL_NAME: &'static str = "serviceaccounts";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ServiceAccount {

--- a/src/v1_20/api/discovery/v1beta1/endpoint_slice.rs
+++ b/src/v1_20/api/discovery/v1beta1/endpoint_slice.rs
@@ -495,7 +495,10 @@ impl crate::Resource for EndpointSlice {
     const API_VERSION: &'static str = "discovery.k8s.io/v1beta1";
     const GROUP: &'static str = "discovery.k8s.io";
     const KIND: &'static str = "EndpointSlice";
+    const PLURAL_NAME: &'static str = "endpointslices";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for EndpointSlice {

--- a/src/v1_20/api/events/v1/event.rs
+++ b/src/v1_20/api/events/v1/event.rs
@@ -527,7 +527,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "events.k8s.io/v1";
     const GROUP: &'static str = "events.k8s.io";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_20/api/events/v1beta1/event.rs
+++ b/src/v1_20/api/events/v1beta1/event.rs
@@ -527,7 +527,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "events.k8s.io/v1beta1";
     const GROUP: &'static str = "events.k8s.io";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_20/api/extensions/v1beta1/ingress.rs
+++ b/src/v1_20/api/extensions/v1beta1/ingress.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Ingress {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Ingress";
+    const PLURAL_NAME: &'static str = "ingresses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Ingress {

--- a/src/v1_20/api/flowcontrol/v1alpha1/flow_schema.rs
+++ b/src/v1_20/api/flowcontrol/v1alpha1/flow_schema.rs
@@ -550,7 +550,10 @@ impl crate::Resource for FlowSchema {
     const API_VERSION: &'static str = "flowcontrol.apiserver.k8s.io/v1alpha1";
     const GROUP: &'static str = "flowcontrol.apiserver.k8s.io";
     const KIND: &'static str = "FlowSchema";
+    const PLURAL_NAME: &'static str = "flowschemas";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for FlowSchema {

--- a/src/v1_20/api/flowcontrol/v1alpha1/priority_level_configuration.rs
+++ b/src/v1_20/api/flowcontrol/v1alpha1/priority_level_configuration.rs
@@ -550,7 +550,10 @@ impl crate::Resource for PriorityLevelConfiguration {
     const API_VERSION: &'static str = "flowcontrol.apiserver.k8s.io/v1alpha1";
     const GROUP: &'static str = "flowcontrol.apiserver.k8s.io";
     const KIND: &'static str = "PriorityLevelConfiguration";
+    const PLURAL_NAME: &'static str = "prioritylevelconfigurations";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityLevelConfiguration {

--- a/src/v1_20/api/flowcontrol/v1beta1/flow_schema.rs
+++ b/src/v1_20/api/flowcontrol/v1beta1/flow_schema.rs
@@ -550,7 +550,10 @@ impl crate::Resource for FlowSchema {
     const API_VERSION: &'static str = "flowcontrol.apiserver.k8s.io/v1beta1";
     const GROUP: &'static str = "flowcontrol.apiserver.k8s.io";
     const KIND: &'static str = "FlowSchema";
+    const PLURAL_NAME: &'static str = "flowschemas";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for FlowSchema {

--- a/src/v1_20/api/flowcontrol/v1beta1/priority_level_configuration.rs
+++ b/src/v1_20/api/flowcontrol/v1beta1/priority_level_configuration.rs
@@ -550,7 +550,10 @@ impl crate::Resource for PriorityLevelConfiguration {
     const API_VERSION: &'static str = "flowcontrol.apiserver.k8s.io/v1beta1";
     const GROUP: &'static str = "flowcontrol.apiserver.k8s.io";
     const KIND: &'static str = "PriorityLevelConfiguration";
+    const PLURAL_NAME: &'static str = "prioritylevelconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityLevelConfiguration {

--- a/src/v1_20/api/networking/v1/ingress.rs
+++ b/src/v1_20/api/networking/v1/ingress.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Ingress {
     const API_VERSION: &'static str = "networking.k8s.io/v1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "Ingress";
+    const PLURAL_NAME: &'static str = "ingresses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Ingress {

--- a/src/v1_20/api/networking/v1/ingress_class.rs
+++ b/src/v1_20/api/networking/v1/ingress_class.rs
@@ -373,7 +373,10 @@ impl crate::Resource for IngressClass {
     const API_VERSION: &'static str = "networking.k8s.io/v1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "IngressClass";
+    const PLURAL_NAME: &'static str = "ingressclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for IngressClass {

--- a/src/v1_20/api/networking/v1/network_policy.rs
+++ b/src/v1_20/api/networking/v1/network_policy.rs
@@ -489,7 +489,10 @@ impl crate::Resource for NetworkPolicy {
     const API_VERSION: &'static str = "networking.k8s.io/v1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "NetworkPolicy";
+    const PLURAL_NAME: &'static str = "networkpolicies";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for NetworkPolicy {

--- a/src/v1_20/api/networking/v1beta1/ingress.rs
+++ b/src/v1_20/api/networking/v1beta1/ingress.rs
@@ -684,7 +684,10 @@ impl crate::Resource for Ingress {
     const API_VERSION: &'static str = "networking.k8s.io/v1beta1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "Ingress";
+    const PLURAL_NAME: &'static str = "ingresses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Ingress {

--- a/src/v1_20/api/networking/v1beta1/ingress_class.rs
+++ b/src/v1_20/api/networking/v1beta1/ingress_class.rs
@@ -373,7 +373,10 @@ impl crate::Resource for IngressClass {
     const API_VERSION: &'static str = "networking.k8s.io/v1beta1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "IngressClass";
+    const PLURAL_NAME: &'static str = "ingressclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for IngressClass {

--- a/src/v1_20/api/node/v1/runtime_class.rs
+++ b/src/v1_20/api/node/v1/runtime_class.rs
@@ -381,7 +381,10 @@ impl crate::Resource for RuntimeClass {
     const API_VERSION: &'static str = "node.k8s.io/v1";
     const GROUP: &'static str = "node.k8s.io";
     const KIND: &'static str = "RuntimeClass";
+    const PLURAL_NAME: &'static str = "runtimeclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for RuntimeClass {

--- a/src/v1_20/api/node/v1alpha1/runtime_class.rs
+++ b/src/v1_20/api/node/v1alpha1/runtime_class.rs
@@ -373,7 +373,10 @@ impl crate::Resource for RuntimeClass {
     const API_VERSION: &'static str = "node.k8s.io/v1alpha1";
     const GROUP: &'static str = "node.k8s.io";
     const KIND: &'static str = "RuntimeClass";
+    const PLURAL_NAME: &'static str = "runtimeclasses";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for RuntimeClass {

--- a/src/v1_20/api/node/v1beta1/runtime_class.rs
+++ b/src/v1_20/api/node/v1beta1/runtime_class.rs
@@ -379,7 +379,10 @@ impl crate::Resource for RuntimeClass {
     const API_VERSION: &'static str = "node.k8s.io/v1beta1";
     const GROUP: &'static str = "node.k8s.io";
     const KIND: &'static str = "RuntimeClass";
+    const PLURAL_NAME: &'static str = "runtimeclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for RuntimeClass {

--- a/src/v1_20/api/policy/v1beta1/eviction.rs
+++ b/src/v1_20/api/policy/v1beta1/eviction.rs
@@ -65,7 +65,10 @@ impl crate::Resource for Eviction {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "Eviction";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Eviction {

--- a/src/v1_20/api/policy/v1beta1/pod_disruption_budget.rs
+++ b/src/v1_20/api/policy/v1beta1/pod_disruption_budget.rs
@@ -683,7 +683,10 @@ impl crate::Resource for PodDisruptionBudget {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "PodDisruptionBudget";
+    const PLURAL_NAME: &'static str = "poddisruptionbudgets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodDisruptionBudget {

--- a/src/v1_20/api/policy/v1beta1/pod_security_policy.rs
+++ b/src/v1_20/api/policy/v1beta1/pod_security_policy.rs
@@ -373,7 +373,10 @@ impl crate::Resource for PodSecurityPolicy {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "PodSecurityPolicy";
+    const PLURAL_NAME: &'static str = "podsecuritypolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PodSecurityPolicy {

--- a/src/v1_20/api/rbac/v1/cluster_role.rs
+++ b/src/v1_20/api/rbac/v1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_20/api/rbac/v1/cluster_role_binding.rs
+++ b/src/v1_20/api/rbac/v1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_20/api/rbac/v1/role.rs
+++ b/src/v1_20/api/rbac/v1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_20/api/rbac/v1/role_binding.rs
+++ b/src/v1_20/api/rbac/v1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_20/api/rbac/v1alpha1/cluster_role.rs
+++ b/src/v1_20/api/rbac/v1alpha1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_20/api/rbac/v1alpha1/cluster_role_binding.rs
+++ b/src/v1_20/api/rbac/v1alpha1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_20/api/rbac/v1alpha1/role.rs
+++ b/src/v1_20/api/rbac/v1alpha1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_20/api/rbac/v1alpha1/role_binding.rs
+++ b/src/v1_20/api/rbac/v1alpha1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_20/api/rbac/v1beta1/cluster_role.rs
+++ b/src/v1_20/api/rbac/v1beta1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_20/api/rbac/v1beta1/cluster_role_binding.rs
+++ b/src/v1_20/api/rbac/v1beta1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_20/api/rbac/v1beta1/role.rs
+++ b/src/v1_20/api/rbac/v1beta1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_20/api/rbac/v1beta1/role_binding.rs
+++ b/src/v1_20/api/rbac/v1beta1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_20/api/scheduling/v1/priority_class.rs
+++ b/src/v1_20/api/scheduling/v1/priority_class.rs
@@ -382,7 +382,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_20/api/scheduling/v1alpha1/priority_class.rs
+++ b/src/v1_20/api/scheduling/v1alpha1/priority_class.rs
@@ -382,7 +382,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1alpha1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_20/api/scheduling/v1beta1/priority_class.rs
+++ b/src/v1_20/api/scheduling/v1beta1/priority_class.rs
@@ -382,7 +382,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1beta1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_20/api/storage/v1/csi_driver.rs
+++ b/src/v1_20/api/storage/v1/csi_driver.rs
@@ -373,7 +373,10 @@ impl crate::Resource for CSIDriver {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSIDriver";
+    const PLURAL_NAME: &'static str = "csidrivers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSIDriver {

--- a/src/v1_20/api/storage/v1/csi_node.rs
+++ b/src/v1_20/api/storage/v1/csi_node.rs
@@ -373,7 +373,10 @@ impl crate::Resource for CSINode {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSINode";
+    const PLURAL_NAME: &'static str = "csinodes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSINode {

--- a/src/v1_20/api/storage/v1/storage_class.rs
+++ b/src/v1_20/api/storage/v1/storage_class.rs
@@ -393,7 +393,10 @@ impl crate::Resource for StorageClass {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "StorageClass";
+    const PLURAL_NAME: &'static str = "storageclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageClass {

--- a/src/v1_20/api/storage/v1/volume_attachment.rs
+++ b/src/v1_20/api/storage/v1/volume_attachment.rs
@@ -552,7 +552,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_20/api/storage/v1alpha1/volume_attachment.rs
+++ b/src/v1_20/api/storage/v1alpha1/volume_attachment.rs
@@ -378,7 +378,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1alpha1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_20/api/storage/v1beta1/csi_driver.rs
+++ b/src/v1_20/api/storage/v1beta1/csi_driver.rs
@@ -373,7 +373,10 @@ impl crate::Resource for CSIDriver {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSIDriver";
+    const PLURAL_NAME: &'static str = "csidrivers";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSIDriver {

--- a/src/v1_20/api/storage/v1beta1/csi_node.rs
+++ b/src/v1_20/api/storage/v1beta1/csi_node.rs
@@ -373,7 +373,10 @@ impl crate::Resource for CSINode {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSINode";
+    const PLURAL_NAME: &'static str = "csinodes";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSINode {

--- a/src/v1_20/api/storage/v1beta1/storage_class.rs
+++ b/src/v1_20/api/storage/v1beta1/storage_class.rs
@@ -393,7 +393,10 @@ impl crate::Resource for StorageClass {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "StorageClass";
+    const PLURAL_NAME: &'static str = "storageclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageClass {

--- a/src/v1_20/api/storage/v1beta1/volume_attachment.rs
+++ b/src/v1_20/api/storage/v1beta1/volume_attachment.rs
@@ -378,7 +378,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_20/apiextensions_apiserver/pkg/apis/apiextensions/v1/custom_resource_definition.rs
+++ b/src/v1_20/apiextensions_apiserver/pkg/apis/apiextensions/v1/custom_resource_definition.rs
@@ -549,7 +549,10 @@ impl crate::Resource for CustomResourceDefinition {
     const API_VERSION: &'static str = "apiextensions.k8s.io/v1";
     const GROUP: &'static str = "apiextensions.k8s.io";
     const KIND: &'static str = "CustomResourceDefinition";
+    const PLURAL_NAME: &'static str = "customresourcedefinitions";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CustomResourceDefinition {

--- a/src/v1_20/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
+++ b/src/v1_20/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
@@ -549,7 +549,10 @@ impl crate::Resource for CustomResourceDefinition {
     const API_VERSION: &'static str = "apiextensions.k8s.io/v1beta1";
     const GROUP: &'static str = "apiextensions.k8s.io";
     const KIND: &'static str = "CustomResourceDefinition";
+    const PLURAL_NAME: &'static str = "customresourcedefinitions";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CustomResourceDefinition {

--- a/src/v1_20/apimachinery/pkg/apis/meta/v1/api_group.rs
+++ b/src/v1_20/apimachinery/pkg/apis/meta/v1/api_group.rs
@@ -20,7 +20,10 @@ impl crate::Resource for APIGroup {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIGroup";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIGroup {

--- a/src/v1_20/apimachinery/pkg/apis/meta/v1/api_group_list.rs
+++ b/src/v1_20/apimachinery/pkg/apis/meta/v1/api_group_list.rs
@@ -11,7 +11,10 @@ impl crate::Resource for APIGroupList {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIGroupList";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIGroupList {

--- a/src/v1_20/apimachinery/pkg/apis/meta/v1/api_resource_list.rs
+++ b/src/v1_20/apimachinery/pkg/apis/meta/v1/api_resource_list.rs
@@ -14,7 +14,10 @@ impl crate::Resource for APIResourceList {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIResourceList";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIResourceList {

--- a/src/v1_20/apimachinery/pkg/apis/meta/v1/api_versions.rs
+++ b/src/v1_20/apimachinery/pkg/apis/meta/v1/api_versions.rs
@@ -14,7 +14,10 @@ impl crate::Resource for APIVersions {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIVersions";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIVersions {

--- a/src/v1_20/apimachinery/pkg/apis/meta/v1/status.rs
+++ b/src/v1_20/apimachinery/pkg/apis/meta/v1/status.rs
@@ -26,7 +26,10 @@ impl crate::Resource for Status {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Status";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Status {

--- a/src/v1_20/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
+++ b/src/v1_20/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
@@ -549,7 +549,10 @@ impl crate::Resource for APIService {
     const API_VERSION: &'static str = "apiregistration.k8s.io/v1";
     const GROUP: &'static str = "apiregistration.k8s.io";
     const KIND: &'static str = "APIService";
+    const PLURAL_NAME: &'static str = "apiservices";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for APIService {

--- a/src/v1_20/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
+++ b/src/v1_20/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
@@ -549,7 +549,10 @@ impl crate::Resource for APIService {
     const API_VERSION: &'static str = "apiregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "apiregistration.k8s.io";
     const KIND: &'static str = "APIService";
+    const PLURAL_NAME: &'static str = "apiservices";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for APIService {

--- a/src/v1_20/list.rs
+++ b/src/v1_20/list.rs
@@ -14,7 +14,10 @@ impl<T> crate::Resource for List<T> where T: crate::ListableResource {
     const API_VERSION: &'static str = <T as crate::Resource>::API_VERSION;
     const GROUP: &'static str = <T as crate::Resource>::GROUP;
     const KIND: &'static str = <T as crate::ListableResource>::LIST_KIND;
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = <T as crate::Resource>::VERSION;
+    const NAMESPACED: bool = <T as crate::Resource>::NAMESPACED;
+    type Scope = <T as crate::Resource>::Scope;
 }
 
 impl<T> crate::Metadata for List<T> where T: crate::ListableResource {

--- a/src/v1_21/api/admissionregistration/v1/mutating_webhook_configuration.rs
+++ b/src/v1_21/api/admissionregistration/v1/mutating_webhook_configuration.rs
@@ -361,7 +361,10 @@ impl crate::Resource for MutatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "MutatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "mutatingwebhookconfigurations";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for MutatingWebhookConfiguration {

--- a/src/v1_21/api/admissionregistration/v1/validating_webhook_configuration.rs
+++ b/src/v1_21/api/admissionregistration/v1/validating_webhook_configuration.rs
@@ -361,7 +361,10 @@ impl crate::Resource for ValidatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "ValidatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "validatingwebhookconfigurations";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ValidatingWebhookConfiguration {

--- a/src/v1_21/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
+++ b/src/v1_21/api/admissionregistration/v1beta1/mutating_webhook_configuration.rs
@@ -361,7 +361,10 @@ impl crate::Resource for MutatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "MutatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "mutatingwebhookconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for MutatingWebhookConfiguration {

--- a/src/v1_21/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
+++ b/src/v1_21/api/admissionregistration/v1beta1/validating_webhook_configuration.rs
@@ -361,7 +361,10 @@ impl crate::Resource for ValidatingWebhookConfiguration {
     const API_VERSION: &'static str = "admissionregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "admissionregistration.k8s.io";
     const KIND: &'static str = "ValidatingWebhookConfiguration";
+    const PLURAL_NAME: &'static str = "validatingwebhookconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ValidatingWebhookConfiguration {

--- a/src/v1_21/api/apiserverinternal/v1alpha1/storage_version.rs
+++ b/src/v1_21/api/apiserverinternal/v1alpha1/storage_version.rs
@@ -539,7 +539,10 @@ impl crate::Resource for StorageVersion {
     const API_VERSION: &'static str = "internal.apiserver.k8s.io/v1alpha1";
     const GROUP: &'static str = "internal.apiserver.k8s.io";
     const KIND: &'static str = "StorageVersion";
+    const PLURAL_NAME: &'static str = "storageversions";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageVersion {

--- a/src/v1_21/api/apps/v1/controller_revision.rs
+++ b/src/v1_21/api/apps/v1/controller_revision.rs
@@ -480,7 +480,10 @@ impl crate::Resource for ControllerRevision {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ControllerRevision";
+    const PLURAL_NAME: &'static str = "controllerrevisions";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ControllerRevision {

--- a/src/v1_21/api/apps/v1/daemon_set.rs
+++ b/src/v1_21/api/apps/v1/daemon_set.rs
@@ -672,7 +672,10 @@ impl crate::Resource for DaemonSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "DaemonSet";
+    const PLURAL_NAME: &'static str = "daemonsets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for DaemonSet {

--- a/src/v1_21/api/apps/v1/deployment.rs
+++ b/src/v1_21/api/apps/v1/deployment.rs
@@ -672,7 +672,10 @@ impl crate::Resource for Deployment {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "Deployment";
+    const PLURAL_NAME: &'static str = "deployments";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Deployment {

--- a/src/v1_21/api/apps/v1/replica_set.rs
+++ b/src/v1_21/api/apps/v1/replica_set.rs
@@ -672,7 +672,10 @@ impl crate::Resource for ReplicaSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "ReplicaSet";
+    const PLURAL_NAME: &'static str = "replicasets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicaSet {

--- a/src/v1_21/api/apps/v1/stateful_set.rs
+++ b/src/v1_21/api/apps/v1/stateful_set.rs
@@ -674,7 +674,10 @@ impl crate::Resource for StatefulSet {
     const API_VERSION: &'static str = "apps/v1";
     const GROUP: &'static str = "apps";
     const KIND: &'static str = "StatefulSet";
+    const PLURAL_NAME: &'static str = "statefulsets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for StatefulSet {

--- a/src/v1_21/api/authentication/v1/token_request.rs
+++ b/src/v1_21/api/authentication/v1/token_request.rs
@@ -65,7 +65,10 @@ impl crate::Resource for TokenRequest {
     const API_VERSION: &'static str = "authentication.k8s.io/v1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenRequest";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenRequest {

--- a/src/v1_21/api/authentication/v1/token_review.rs
+++ b/src/v1_21/api/authentication/v1/token_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for TokenReview {
     const API_VERSION: &'static str = "authentication.k8s.io/v1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenReview";
+    const PLURAL_NAME: &'static str = "tokenreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenReview {

--- a/src/v1_21/api/authentication/v1beta1/token_review.rs
+++ b/src/v1_21/api/authentication/v1beta1/token_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for TokenReview {
     const API_VERSION: &'static str = "authentication.k8s.io/v1beta1";
     const GROUP: &'static str = "authentication.k8s.io";
     const KIND: &'static str = "TokenReview";
+    const PLURAL_NAME: &'static str = "tokenreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for TokenReview {

--- a/src/v1_21/api/authorization/v1/local_subject_access_review.rs
+++ b/src/v1_21/api/authorization/v1/local_subject_access_review.rs
@@ -61,7 +61,10 @@ impl crate::Resource for LocalSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "LocalSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "localsubjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for LocalSubjectAccessReview {

--- a/src/v1_21/api/authorization/v1/self_subject_access_review.rs
+++ b/src/v1_21/api/authorization/v1/self_subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "selfsubjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectAccessReview {

--- a/src/v1_21/api/authorization/v1/self_subject_rules_review.rs
+++ b/src/v1_21/api/authorization/v1/self_subject_rules_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectRulesReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectRulesReview";
+    const PLURAL_NAME: &'static str = "selfsubjectrulesreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectRulesReview {

--- a/src/v1_21/api/authorization/v1/subject_access_review.rs
+++ b/src/v1_21/api/authorization/v1/subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SubjectAccessReview";
+    const PLURAL_NAME: &'static str = "subjectaccessreviews";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SubjectAccessReview {

--- a/src/v1_21/api/authorization/v1beta1/local_subject_access_review.rs
+++ b/src/v1_21/api/authorization/v1beta1/local_subject_access_review.rs
@@ -61,7 +61,10 @@ impl crate::Resource for LocalSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "LocalSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "localsubjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for LocalSubjectAccessReview {

--- a/src/v1_21/api/authorization/v1beta1/self_subject_access_review.rs
+++ b/src/v1_21/api/authorization/v1beta1/self_subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectAccessReview";
+    const PLURAL_NAME: &'static str = "selfsubjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectAccessReview {

--- a/src/v1_21/api/authorization/v1beta1/self_subject_rules_review.rs
+++ b/src/v1_21/api/authorization/v1beta1/self_subject_rules_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SelfSubjectRulesReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SelfSubjectRulesReview";
+    const PLURAL_NAME: &'static str = "selfsubjectrulesreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SelfSubjectRulesReview {

--- a/src/v1_21/api/authorization/v1beta1/subject_access_review.rs
+++ b/src/v1_21/api/authorization/v1beta1/subject_access_review.rs
@@ -54,7 +54,10 @@ impl crate::Resource for SubjectAccessReview {
     const API_VERSION: &'static str = "authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "authorization.k8s.io";
     const KIND: &'static str = "SubjectAccessReview";
+    const PLURAL_NAME: &'static str = "subjectaccessreviews";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for SubjectAccessReview {

--- a/src/v1_21/api/autoscaling/v1/horizontal_pod_autoscaler.rs
+++ b/src/v1_21/api/autoscaling/v1/horizontal_pod_autoscaler.rs
@@ -672,7 +672,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_21/api/autoscaling/v1/scale.rs
+++ b/src/v1_21/api/autoscaling/v1/scale.rs
@@ -789,7 +789,10 @@ impl crate::Resource for Scale {
     const API_VERSION: &'static str = "autoscaling/v1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "Scale";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Scale {

--- a/src/v1_21/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
+++ b/src/v1_21/api/autoscaling/v2beta1/horizontal_pod_autoscaler.rs
@@ -672,7 +672,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v2beta1";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v2beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_21/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
+++ b/src/v1_21/api/autoscaling/v2beta2/horizontal_pod_autoscaler.rs
@@ -672,7 +672,10 @@ impl crate::Resource for HorizontalPodAutoscaler {
     const API_VERSION: &'static str = "autoscaling/v2beta2";
     const GROUP: &'static str = "autoscaling";
     const KIND: &'static str = "HorizontalPodAutoscaler";
+    const PLURAL_NAME: &'static str = "horizontalpodautoscalers";
     const VERSION: &'static str = "v2beta2";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for HorizontalPodAutoscaler {

--- a/src/v1_21/api/batch/v1/cron_job.rs
+++ b/src/v1_21/api/batch/v1/cron_job.rs
@@ -672,7 +672,10 @@ impl crate::Resource for CronJob {
     const API_VERSION: &'static str = "batch/v1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "CronJob";
+    const PLURAL_NAME: &'static str = "cronjobs";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CronJob {

--- a/src/v1_21/api/batch/v1/job.rs
+++ b/src/v1_21/api/batch/v1/job.rs
@@ -672,7 +672,10 @@ impl crate::Resource for Job {
     const API_VERSION: &'static str = "batch/v1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "Job";
+    const PLURAL_NAME: &'static str = "jobs";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Job {

--- a/src/v1_21/api/batch/v1beta1/cron_job.rs
+++ b/src/v1_21/api/batch/v1beta1/cron_job.rs
@@ -672,7 +672,10 @@ impl crate::Resource for CronJob {
     const API_VERSION: &'static str = "batch/v1beta1";
     const GROUP: &'static str = "batch";
     const KIND: &'static str = "CronJob";
+    const PLURAL_NAME: &'static str = "cronjobs";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CronJob {

--- a/src/v1_21/api/certificates/v1/certificate_signing_request.rs
+++ b/src/v1_21/api/certificates/v1/certificate_signing_request.rs
@@ -717,7 +717,10 @@ impl crate::Resource for CertificateSigningRequest {
     const API_VERSION: &'static str = "certificates.k8s.io/v1";
     const GROUP: &'static str = "certificates.k8s.io";
     const KIND: &'static str = "CertificateSigningRequest";
+    const PLURAL_NAME: &'static str = "certificatesigningrequests";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CertificateSigningRequest {

--- a/src/v1_21/api/certificates/v1beta1/certificate_signing_request.rs
+++ b/src/v1_21/api/certificates/v1beta1/certificate_signing_request.rs
@@ -711,7 +711,10 @@ impl crate::Resource for CertificateSigningRequest {
     const API_VERSION: &'static str = "certificates.k8s.io/v1beta1";
     const GROUP: &'static str = "certificates.k8s.io";
     const KIND: &'static str = "CertificateSigningRequest";
+    const PLURAL_NAME: &'static str = "certificatesigningrequests";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CertificateSigningRequest {

--- a/src/v1_21/api/coordination/v1/lease.rs
+++ b/src/v1_21/api/coordination/v1/lease.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Lease {
     const API_VERSION: &'static str = "coordination.k8s.io/v1";
     const GROUP: &'static str = "coordination.k8s.io";
     const KIND: &'static str = "Lease";
+    const PLURAL_NAME: &'static str = "leases";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Lease {

--- a/src/v1_21/api/coordination/v1beta1/lease.rs
+++ b/src/v1_21/api/coordination/v1beta1/lease.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Lease {
     const API_VERSION: &'static str = "coordination.k8s.io/v1beta1";
     const GROUP: &'static str = "coordination.k8s.io";
     const KIND: &'static str = "Lease";
+    const PLURAL_NAME: &'static str = "leases";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Lease {

--- a/src/v1_21/api/core/v1/binding.rs
+++ b/src/v1_21/api/core/v1/binding.rs
@@ -106,7 +106,10 @@ impl crate::Resource for Binding {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Binding";
+    const PLURAL_NAME: &'static str = "bindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::Metadata for Binding {

--- a/src/v1_21/api/core/v1/component_status.rs
+++ b/src/v1_21/api/core/v1/component_status.rs
@@ -170,7 +170,10 @@ impl crate::Resource for ComponentStatus {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ComponentStatus";
+    const PLURAL_NAME: &'static str = "componentstatuses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ComponentStatus {

--- a/src/v1_21/api/core/v1/config_map.rs
+++ b/src/v1_21/api/core/v1/config_map.rs
@@ -483,7 +483,10 @@ impl crate::Resource for ConfigMap {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ConfigMap";
+    const PLURAL_NAME: &'static str = "configmaps";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ConfigMap {

--- a/src/v1_21/api/core/v1/endpoints.rs
+++ b/src/v1_21/api/core/v1/endpoints.rs
@@ -488,7 +488,10 @@ impl crate::Resource for Endpoints {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Endpoints";
+    const PLURAL_NAME: &'static str = "endpoints";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Endpoints {

--- a/src/v1_21/api/core/v1/ephemeral_containers.rs
+++ b/src/v1_21/api/core/v1/ephemeral_containers.rs
@@ -209,7 +209,10 @@ impl crate::Resource for EphemeralContainers {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "EphemeralContainers";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for EphemeralContainers {

--- a/src/v1_21/api/core/v1/event.rs
+++ b/src/v1_21/api/core/v1/event.rs
@@ -516,7 +516,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_21/api/core/v1/limit_range.rs
+++ b/src/v1_21/api/core/v1/limit_range.rs
@@ -477,7 +477,10 @@ impl crate::Resource for LimitRange {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "LimitRange";
+    const PLURAL_NAME: &'static str = "limitranges";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for LimitRange {

--- a/src/v1_21/api/core/v1/namespace.rs
+++ b/src/v1_21/api/core/v1/namespace.rs
@@ -543,7 +543,10 @@ impl crate::Resource for Namespace {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Namespace";
+    const PLURAL_NAME: &'static str = "namespaces";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for Namespace {

--- a/src/v1_21/api/core/v1/node.rs
+++ b/src/v1_21/api/core/v1/node.rs
@@ -1018,7 +1018,10 @@ impl crate::Resource for Node {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Node";
+    const PLURAL_NAME: &'static str = "nodes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for Node {

--- a/src/v1_21/api/core/v1/persistent_volume.rs
+++ b/src/v1_21/api/core/v1/persistent_volume.rs
@@ -538,7 +538,10 @@ impl crate::Resource for PersistentVolume {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PersistentVolume";
+    const PLURAL_NAME: &'static str = "persistentvolumes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PersistentVolume {

--- a/src/v1_21/api/core/v1/persistent_volume_claim.rs
+++ b/src/v1_21/api/core/v1/persistent_volume_claim.rs
@@ -672,7 +672,10 @@ impl crate::Resource for PersistentVolumeClaim {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PersistentVolumeClaim";
+    const PLURAL_NAME: &'static str = "persistentvolumeclaims";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PersistentVolumeClaim {

--- a/src/v1_21/api/core/v1/pod.rs
+++ b/src/v1_21/api/core/v1/pod.rs
@@ -1778,7 +1778,10 @@ impl crate::Resource for Pod {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Pod";
+    const PLURAL_NAME: &'static str = "pods";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Pod {

--- a/src/v1_21/api/core/v1/pod_template.rs
+++ b/src/v1_21/api/core/v1/pod_template.rs
@@ -477,7 +477,10 @@ impl crate::Resource for PodTemplate {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "PodTemplate";
+    const PLURAL_NAME: &'static str = "podtemplates";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodTemplate {

--- a/src/v1_21/api/core/v1/replication_controller.rs
+++ b/src/v1_21/api/core/v1/replication_controller.rs
@@ -672,7 +672,10 @@ impl crate::Resource for ReplicationController {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ReplicationController";
+    const PLURAL_NAME: &'static str = "replicationcontrollers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ReplicationController {

--- a/src/v1_21/api/core/v1/resource_quota.rs
+++ b/src/v1_21/api/core/v1/resource_quota.rs
@@ -672,7 +672,10 @@ impl crate::Resource for ResourceQuota {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ResourceQuota";
+    const PLURAL_NAME: &'static str = "resourcequotas";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ResourceQuota {

--- a/src/v1_21/api/core/v1/secret.rs
+++ b/src/v1_21/api/core/v1/secret.rs
@@ -486,7 +486,10 @@ impl crate::Resource for Secret {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Secret";
+    const PLURAL_NAME: &'static str = "secrets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Secret {

--- a/src/v1_21/api/core/v1/service.rs
+++ b/src/v1_21/api/core/v1/service.rs
@@ -1169,7 +1169,10 @@ impl crate::Resource for Service {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Service";
+    const PLURAL_NAME: &'static str = "services";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Service {

--- a/src/v1_21/api/core/v1/service_account.rs
+++ b/src/v1_21/api/core/v1/service_account.rs
@@ -483,7 +483,10 @@ impl crate::Resource for ServiceAccount {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "ServiceAccount";
+    const PLURAL_NAME: &'static str = "serviceaccounts";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for ServiceAccount {

--- a/src/v1_21/api/discovery/v1/endpoint_slice.rs
+++ b/src/v1_21/api/discovery/v1/endpoint_slice.rs
@@ -483,7 +483,10 @@ impl crate::Resource for EndpointSlice {
     const API_VERSION: &'static str = "discovery.k8s.io/v1";
     const GROUP: &'static str = "discovery.k8s.io";
     const KIND: &'static str = "EndpointSlice";
+    const PLURAL_NAME: &'static str = "endpointslices";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for EndpointSlice {

--- a/src/v1_21/api/discovery/v1beta1/endpoint_slice.rs
+++ b/src/v1_21/api/discovery/v1beta1/endpoint_slice.rs
@@ -483,7 +483,10 @@ impl crate::Resource for EndpointSlice {
     const API_VERSION: &'static str = "discovery.k8s.io/v1beta1";
     const GROUP: &'static str = "discovery.k8s.io";
     const KIND: &'static str = "EndpointSlice";
+    const PLURAL_NAME: &'static str = "endpointslices";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for EndpointSlice {

--- a/src/v1_21/api/events/v1/event.rs
+++ b/src/v1_21/api/events/v1/event.rs
@@ -516,7 +516,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "events.k8s.io/v1";
     const GROUP: &'static str = "events.k8s.io";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_21/api/events/v1beta1/event.rs
+++ b/src/v1_21/api/events/v1beta1/event.rs
@@ -516,7 +516,10 @@ impl crate::Resource for Event {
     const API_VERSION: &'static str = "events.k8s.io/v1beta1";
     const GROUP: &'static str = "events.k8s.io";
     const KIND: &'static str = "Event";
+    const PLURAL_NAME: &'static str = "events";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Event {

--- a/src/v1_21/api/extensions/v1beta1/ingress.rs
+++ b/src/v1_21/api/extensions/v1beta1/ingress.rs
@@ -672,7 +672,10 @@ impl crate::Resource for Ingress {
     const API_VERSION: &'static str = "extensions/v1beta1";
     const GROUP: &'static str = "extensions";
     const KIND: &'static str = "Ingress";
+    const PLURAL_NAME: &'static str = "ingresses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Ingress {

--- a/src/v1_21/api/flowcontrol/v1beta1/flow_schema.rs
+++ b/src/v1_21/api/flowcontrol/v1beta1/flow_schema.rs
@@ -538,7 +538,10 @@ impl crate::Resource for FlowSchema {
     const API_VERSION: &'static str = "flowcontrol.apiserver.k8s.io/v1beta1";
     const GROUP: &'static str = "flowcontrol.apiserver.k8s.io";
     const KIND: &'static str = "FlowSchema";
+    const PLURAL_NAME: &'static str = "flowschemas";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for FlowSchema {

--- a/src/v1_21/api/flowcontrol/v1beta1/priority_level_configuration.rs
+++ b/src/v1_21/api/flowcontrol/v1beta1/priority_level_configuration.rs
@@ -538,7 +538,10 @@ impl crate::Resource for PriorityLevelConfiguration {
     const API_VERSION: &'static str = "flowcontrol.apiserver.k8s.io/v1beta1";
     const GROUP: &'static str = "flowcontrol.apiserver.k8s.io";
     const KIND: &'static str = "PriorityLevelConfiguration";
+    const PLURAL_NAME: &'static str = "prioritylevelconfigurations";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityLevelConfiguration {

--- a/src/v1_21/api/networking/v1/ingress.rs
+++ b/src/v1_21/api/networking/v1/ingress.rs
@@ -672,7 +672,10 @@ impl crate::Resource for Ingress {
     const API_VERSION: &'static str = "networking.k8s.io/v1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "Ingress";
+    const PLURAL_NAME: &'static str = "ingresses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Ingress {

--- a/src/v1_21/api/networking/v1/ingress_class.rs
+++ b/src/v1_21/api/networking/v1/ingress_class.rs
@@ -361,7 +361,10 @@ impl crate::Resource for IngressClass {
     const API_VERSION: &'static str = "networking.k8s.io/v1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "IngressClass";
+    const PLURAL_NAME: &'static str = "ingressclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for IngressClass {

--- a/src/v1_21/api/networking/v1/network_policy.rs
+++ b/src/v1_21/api/networking/v1/network_policy.rs
@@ -477,7 +477,10 @@ impl crate::Resource for NetworkPolicy {
     const API_VERSION: &'static str = "networking.k8s.io/v1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "NetworkPolicy";
+    const PLURAL_NAME: &'static str = "networkpolicies";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for NetworkPolicy {

--- a/src/v1_21/api/networking/v1beta1/ingress.rs
+++ b/src/v1_21/api/networking/v1beta1/ingress.rs
@@ -672,7 +672,10 @@ impl crate::Resource for Ingress {
     const API_VERSION: &'static str = "networking.k8s.io/v1beta1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "Ingress";
+    const PLURAL_NAME: &'static str = "ingresses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Ingress {

--- a/src/v1_21/api/networking/v1beta1/ingress_class.rs
+++ b/src/v1_21/api/networking/v1beta1/ingress_class.rs
@@ -361,7 +361,10 @@ impl crate::Resource for IngressClass {
     const API_VERSION: &'static str = "networking.k8s.io/v1beta1";
     const GROUP: &'static str = "networking.k8s.io";
     const KIND: &'static str = "IngressClass";
+    const PLURAL_NAME: &'static str = "ingressclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for IngressClass {

--- a/src/v1_21/api/node/v1/runtime_class.rs
+++ b/src/v1_21/api/node/v1/runtime_class.rs
@@ -369,7 +369,10 @@ impl crate::Resource for RuntimeClass {
     const API_VERSION: &'static str = "node.k8s.io/v1";
     const GROUP: &'static str = "node.k8s.io";
     const KIND: &'static str = "RuntimeClass";
+    const PLURAL_NAME: &'static str = "runtimeclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for RuntimeClass {

--- a/src/v1_21/api/node/v1alpha1/runtime_class.rs
+++ b/src/v1_21/api/node/v1alpha1/runtime_class.rs
@@ -361,7 +361,10 @@ impl crate::Resource for RuntimeClass {
     const API_VERSION: &'static str = "node.k8s.io/v1alpha1";
     const GROUP: &'static str = "node.k8s.io";
     const KIND: &'static str = "RuntimeClass";
+    const PLURAL_NAME: &'static str = "runtimeclasses";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for RuntimeClass {

--- a/src/v1_21/api/node/v1beta1/runtime_class.rs
+++ b/src/v1_21/api/node/v1beta1/runtime_class.rs
@@ -367,7 +367,10 @@ impl crate::Resource for RuntimeClass {
     const API_VERSION: &'static str = "node.k8s.io/v1beta1";
     const GROUP: &'static str = "node.k8s.io";
     const KIND: &'static str = "RuntimeClass";
+    const PLURAL_NAME: &'static str = "runtimeclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for RuntimeClass {

--- a/src/v1_21/api/policy/v1/pod_disruption_budget.rs
+++ b/src/v1_21/api/policy/v1/pod_disruption_budget.rs
@@ -672,7 +672,10 @@ impl crate::Resource for PodDisruptionBudget {
     const API_VERSION: &'static str = "policy/v1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "PodDisruptionBudget";
+    const PLURAL_NAME: &'static str = "poddisruptionbudgets";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodDisruptionBudget {

--- a/src/v1_21/api/policy/v1beta1/eviction.rs
+++ b/src/v1_21/api/policy/v1beta1/eviction.rs
@@ -65,7 +65,10 @@ impl crate::Resource for Eviction {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "Eviction";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Eviction {

--- a/src/v1_21/api/policy/v1beta1/pod_disruption_budget.rs
+++ b/src/v1_21/api/policy/v1beta1/pod_disruption_budget.rs
@@ -671,7 +671,10 @@ impl crate::Resource for PodDisruptionBudget {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "PodDisruptionBudget";
+    const PLURAL_NAME: &'static str = "poddisruptionbudgets";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for PodDisruptionBudget {

--- a/src/v1_21/api/policy/v1beta1/pod_security_policy.rs
+++ b/src/v1_21/api/policy/v1beta1/pod_security_policy.rs
@@ -361,7 +361,10 @@ impl crate::Resource for PodSecurityPolicy {
     const API_VERSION: &'static str = "policy/v1beta1";
     const GROUP: &'static str = "policy";
     const KIND: &'static str = "PodSecurityPolicy";
+    const PLURAL_NAME: &'static str = "podsecuritypolicies";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PodSecurityPolicy {

--- a/src/v1_21/api/rbac/v1/cluster_role.rs
+++ b/src/v1_21/api/rbac/v1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_21/api/rbac/v1/cluster_role_binding.rs
+++ b/src/v1_21/api/rbac/v1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_21/api/rbac/v1/role.rs
+++ b/src/v1_21/api/rbac/v1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_21/api/rbac/v1/role_binding.rs
+++ b/src/v1_21/api/rbac/v1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_21/api/rbac/v1alpha1/cluster_role.rs
+++ b/src/v1_21/api/rbac/v1alpha1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_21/api/rbac/v1alpha1/cluster_role_binding.rs
+++ b/src/v1_21/api/rbac/v1alpha1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_21/api/rbac/v1alpha1/role.rs
+++ b/src/v1_21/api/rbac/v1alpha1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_21/api/rbac/v1alpha1/role_binding.rs
+++ b/src/v1_21/api/rbac/v1alpha1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1alpha1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_21/api/rbac/v1beta1/cluster_role.rs
+++ b/src/v1_21/api/rbac/v1beta1/cluster_role.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRole {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRole";
+    const PLURAL_NAME: &'static str = "clusterroles";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRole {

--- a/src/v1_21/api/rbac/v1beta1/cluster_role_binding.rs
+++ b/src/v1_21/api/rbac/v1beta1/cluster_role_binding.rs
@@ -364,7 +364,10 @@ impl crate::Resource for ClusterRoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "ClusterRoleBinding";
+    const PLURAL_NAME: &'static str = "clusterrolebindings";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for ClusterRoleBinding {

--- a/src/v1_21/api/rbac/v1beta1/role.rs
+++ b/src/v1_21/api/rbac/v1beta1/role.rs
@@ -477,7 +477,10 @@ impl crate::Resource for Role {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "Role";
+    const PLURAL_NAME: &'static str = "roles";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for Role {

--- a/src/v1_21/api/rbac/v1beta1/role_binding.rs
+++ b/src/v1_21/api/rbac/v1beta1/role_binding.rs
@@ -480,7 +480,10 @@ impl crate::Resource for RoleBinding {
     const API_VERSION: &'static str = "rbac.authorization.k8s.io/v1beta1";
     const GROUP: &'static str = "rbac.authorization.k8s.io";
     const KIND: &'static str = "RoleBinding";
+    const PLURAL_NAME: &'static str = "rolebindings";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for RoleBinding {

--- a/src/v1_21/api/scheduling/v1/priority_class.rs
+++ b/src/v1_21/api/scheduling/v1/priority_class.rs
@@ -370,7 +370,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_21/api/scheduling/v1alpha1/priority_class.rs
+++ b/src/v1_21/api/scheduling/v1alpha1/priority_class.rs
@@ -370,7 +370,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1alpha1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_21/api/scheduling/v1beta1/priority_class.rs
+++ b/src/v1_21/api/scheduling/v1beta1/priority_class.rs
@@ -370,7 +370,10 @@ impl crate::Resource for PriorityClass {
     const API_VERSION: &'static str = "scheduling.k8s.io/v1beta1";
     const GROUP: &'static str = "scheduling.k8s.io";
     const KIND: &'static str = "PriorityClass";
+    const PLURAL_NAME: &'static str = "priorityclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for PriorityClass {

--- a/src/v1_21/api/storage/v1/csi_driver.rs
+++ b/src/v1_21/api/storage/v1/csi_driver.rs
@@ -361,7 +361,10 @@ impl crate::Resource for CSIDriver {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSIDriver";
+    const PLURAL_NAME: &'static str = "csidrivers";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSIDriver {

--- a/src/v1_21/api/storage/v1/csi_node.rs
+++ b/src/v1_21/api/storage/v1/csi_node.rs
@@ -361,7 +361,10 @@ impl crate::Resource for CSINode {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSINode";
+    const PLURAL_NAME: &'static str = "csinodes";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSINode {

--- a/src/v1_21/api/storage/v1/storage_class.rs
+++ b/src/v1_21/api/storage/v1/storage_class.rs
@@ -381,7 +381,10 @@ impl crate::Resource for StorageClass {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "StorageClass";
+    const PLURAL_NAME: &'static str = "storageclasses";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageClass {

--- a/src/v1_21/api/storage/v1/volume_attachment.rs
+++ b/src/v1_21/api/storage/v1/volume_attachment.rs
@@ -540,7 +540,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_21/api/storage/v1alpha1/csi_storage_capacity.rs
+++ b/src/v1_21/api/storage/v1alpha1/csi_storage_capacity.rs
@@ -502,7 +502,10 @@ impl crate::Resource for CSIStorageCapacity {
     const API_VERSION: &'static str = "storage.k8s.io/v1alpha1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSIStorageCapacity";
+    const PLURAL_NAME: &'static str = "csistoragecapacities";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CSIStorageCapacity {

--- a/src/v1_21/api/storage/v1alpha1/volume_attachment.rs
+++ b/src/v1_21/api/storage/v1alpha1/volume_attachment.rs
@@ -366,7 +366,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1alpha1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1alpha1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_21/api/storage/v1beta1/csi_driver.rs
+++ b/src/v1_21/api/storage/v1beta1/csi_driver.rs
@@ -361,7 +361,10 @@ impl crate::Resource for CSIDriver {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSIDriver";
+    const PLURAL_NAME: &'static str = "csidrivers";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSIDriver {

--- a/src/v1_21/api/storage/v1beta1/csi_node.rs
+++ b/src/v1_21/api/storage/v1beta1/csi_node.rs
@@ -361,7 +361,10 @@ impl crate::Resource for CSINode {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSINode";
+    const PLURAL_NAME: &'static str = "csinodes";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CSINode {

--- a/src/v1_21/api/storage/v1beta1/csi_storage_capacity.rs
+++ b/src/v1_21/api/storage/v1beta1/csi_storage_capacity.rs
@@ -502,7 +502,10 @@ impl crate::Resource for CSIStorageCapacity {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "CSIStorageCapacity";
+    const PLURAL_NAME: &'static str = "csistoragecapacities";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = true;
+    type Scope = crate::NamespaceScopedResource;
 }
 
 impl crate::ListableResource for CSIStorageCapacity {

--- a/src/v1_21/api/storage/v1beta1/storage_class.rs
+++ b/src/v1_21/api/storage/v1beta1/storage_class.rs
@@ -381,7 +381,10 @@ impl crate::Resource for StorageClass {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "StorageClass";
+    const PLURAL_NAME: &'static str = "storageclasses";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for StorageClass {

--- a/src/v1_21/api/storage/v1beta1/volume_attachment.rs
+++ b/src/v1_21/api/storage/v1beta1/volume_attachment.rs
@@ -366,7 +366,10 @@ impl crate::Resource for VolumeAttachment {
     const API_VERSION: &'static str = "storage.k8s.io/v1beta1";
     const GROUP: &'static str = "storage.k8s.io";
     const KIND: &'static str = "VolumeAttachment";
+    const PLURAL_NAME: &'static str = "volumeattachments";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for VolumeAttachment {

--- a/src/v1_21/apiextensions_apiserver/pkg/apis/apiextensions/v1/custom_resource_definition.rs
+++ b/src/v1_21/apiextensions_apiserver/pkg/apis/apiextensions/v1/custom_resource_definition.rs
@@ -537,7 +537,10 @@ impl crate::Resource for CustomResourceDefinition {
     const API_VERSION: &'static str = "apiextensions.k8s.io/v1";
     const GROUP: &'static str = "apiextensions.k8s.io";
     const KIND: &'static str = "CustomResourceDefinition";
+    const PLURAL_NAME: &'static str = "customresourcedefinitions";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CustomResourceDefinition {

--- a/src/v1_21/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
+++ b/src/v1_21/apiextensions_apiserver/pkg/apis/apiextensions/v1beta1/custom_resource_definition.rs
@@ -537,7 +537,10 @@ impl crate::Resource for CustomResourceDefinition {
     const API_VERSION: &'static str = "apiextensions.k8s.io/v1beta1";
     const GROUP: &'static str = "apiextensions.k8s.io";
     const KIND: &'static str = "CustomResourceDefinition";
+    const PLURAL_NAME: &'static str = "customresourcedefinitions";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for CustomResourceDefinition {

--- a/src/v1_21/apimachinery/pkg/apis/meta/v1/api_group.rs
+++ b/src/v1_21/apimachinery/pkg/apis/meta/v1/api_group.rs
@@ -20,7 +20,10 @@ impl crate::Resource for APIGroup {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIGroup";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIGroup {

--- a/src/v1_21/apimachinery/pkg/apis/meta/v1/api_group_list.rs
+++ b/src/v1_21/apimachinery/pkg/apis/meta/v1/api_group_list.rs
@@ -11,7 +11,10 @@ impl crate::Resource for APIGroupList {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIGroupList";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIGroupList {

--- a/src/v1_21/apimachinery/pkg/apis/meta/v1/api_resource_list.rs
+++ b/src/v1_21/apimachinery/pkg/apis/meta/v1/api_resource_list.rs
@@ -14,7 +14,10 @@ impl crate::Resource for APIResourceList {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIResourceList";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIResourceList {

--- a/src/v1_21/apimachinery/pkg/apis/meta/v1/api_versions.rs
+++ b/src/v1_21/apimachinery/pkg/apis/meta/v1/api_versions.rs
@@ -14,7 +14,10 @@ impl crate::Resource for APIVersions {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "APIVersions";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl<'de> crate::serde::Deserialize<'de> for APIVersions {

--- a/src/v1_21/apimachinery/pkg/apis/meta/v1/status.rs
+++ b/src/v1_21/apimachinery/pkg/apis/meta/v1/status.rs
@@ -26,7 +26,10 @@ impl crate::Resource for Status {
     const API_VERSION: &'static str = "v1";
     const GROUP: &'static str = "";
     const KIND: &'static str = "Status";
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::Metadata for Status {

--- a/src/v1_21/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
+++ b/src/v1_21/kube_aggregator/pkg/apis/apiregistration/v1/api_service.rs
@@ -537,7 +537,10 @@ impl crate::Resource for APIService {
     const API_VERSION: &'static str = "apiregistration.k8s.io/v1";
     const GROUP: &'static str = "apiregistration.k8s.io";
     const KIND: &'static str = "APIService";
+    const PLURAL_NAME: &'static str = "apiservices";
     const VERSION: &'static str = "v1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for APIService {

--- a/src/v1_21/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
+++ b/src/v1_21/kube_aggregator/pkg/apis/apiregistration/v1beta1/api_service.rs
@@ -537,7 +537,10 @@ impl crate::Resource for APIService {
     const API_VERSION: &'static str = "apiregistration.k8s.io/v1beta1";
     const GROUP: &'static str = "apiregistration.k8s.io";
     const KIND: &'static str = "APIService";
+    const PLURAL_NAME: &'static str = "apiservices";
     const VERSION: &'static str = "v1beta1";
+    const NAMESPACED: bool = false;
+    type Scope = crate::ClusterScopedResource;
 }
 
 impl crate::ListableResource for APIService {

--- a/src/v1_21/list.rs
+++ b/src/v1_21/list.rs
@@ -14,7 +14,10 @@ impl<T> crate::Resource for List<T> where T: crate::ListableResource {
     const API_VERSION: &'static str = <T as crate::Resource>::API_VERSION;
     const GROUP: &'static str = <T as crate::Resource>::GROUP;
     const KIND: &'static str = <T as crate::ListableResource>::LIST_KIND;
+    const PLURAL_NAME: &'static str = "";
     const VERSION: &'static str = <T as crate::Resource>::VERSION;
+    const NAMESPACED: bool = <T as crate::Resource>::NAMESPACED;
+    type Scope = <T as crate::Resource>::Scope;
 }
 
 impl<T> crate::Metadata for List<T> where T: crate::ListableResource {


### PR DESCRIPTION
Continuing from #88 by @MikailBag (I hope you don't mind).

Changes:

- Cleaned up commits to make it easier to review
- Changed to use `ClusterScopedResource` and `NamespaceScopedResource` as described in https://github.com/Arnavion/k8s-openapi/pull/88#issuecomment-827951030
- Add comment for empty `resouce_name`. Lists and Subresources have empty `PLURAL_NAME`.
- Rebased against the latest `master` and generated `v1_21`
- Fixed lines indented with spaces

Closes #65 
Closes #73

Maybe a new version can be released after this?