### PR TITLE
Allow skipping client generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["k8s-openapi-codegen", "k8s-openapi-codegen-common"]
+
 [package]
 name = "k8s-openapi"
 version = "0.12.0"

--- a/k8s-openapi-codegen/src/fixups/mod.rs
+++ b/k8s-openapi-codegen/src/fixups/mod.rs
@@ -1,5 +1,11 @@
 #![deny(unused)]
 
+pub(crate) trait Fixup {
+    fn fixup(&self, spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error>;
+
+    fn requires_client_generation(&self) -> bool;
+}
+
 pub(crate) mod special;
 
 pub(crate) mod upstream_bugs;

--- a/k8s-openapi-codegen/src/fixups/special.rs
+++ b/k8s-openapi-codegen/src/fixups/special.rs
@@ -2,71 +2,99 @@
 
 //! These fixups are for special adjustments to the upstream swagger spec that are needed for the codegen of k8s-openapi.
 
+use crate::fixups::Fixup;
+
 // The composite JSONSchemaProps types need special codegen.
 pub(crate) mod json_ty {
-	pub(crate) fn json_schema_props_or_array(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
-		let mut found = false;
+	use crate::fixups::Fixup;
 
-		for &namespace in &["v1beta1", "v1"] {
-			let definition_path = crate::swagger20::DefinitionPath(format!("io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.{}.JSONSchemaPropsOrArray", namespace));
+	pub(crate) struct JsonSchemaPropsOrArray;
 
-			if let Some(definition) = spec.definitions.get_mut(&definition_path) {
-				if !matches!(definition.kind, crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::JsonSchemaPropsOrArray(_))) {
-					definition.kind = crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::JsonSchemaPropsOrArray(namespace));
-					found = true;
+	impl Fixup for JsonSchemaPropsOrArray {
+		fn fixup(&self, spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
+			let mut found = false;
+	
+			for &namespace in &["v1beta1", "v1"] {
+				let definition_path = crate::swagger20::DefinitionPath(format!("io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.{}.JSONSchemaPropsOrArray", namespace));
+	
+				if let Some(definition) = spec.definitions.get_mut(&definition_path) {
+					if !matches!(definition.kind, crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::JsonSchemaPropsOrArray(_))) {
+						definition.kind = crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::JsonSchemaPropsOrArray(namespace));
+						found = true;
+					}
 				}
+			}
+	
+			if found {
+				Ok(())
+			}
+			else {
+				Err("never applied JSONSchemaPropsOrArray override".into())
 			}
 		}
 
-		if found {
-			Ok(())
-		}
-		else {
-			Err("never applied JSONSchemaPropsOrArray override".into())
+		fn requires_client_generation(&self) -> bool {
+			false
 		}
 	}
 
-	pub(crate) fn json_schema_props_or_bool(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
-		let mut found = false;
+	pub(crate) struct JsonSchemaPropsOrBool;
 
-		for &namespace in &["v1beta1", "v1"] {
-			let definition_path = crate::swagger20::DefinitionPath(format!("io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.{}.JSONSchemaPropsOrBool", namespace));
-
-			if let Some(definition) = spec.definitions.get_mut(&definition_path) {
-				if !matches!(definition.kind, crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::JsonSchemaPropsOrBool(_))) {
-					definition.kind = crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::JsonSchemaPropsOrBool(namespace));
-					found = true;
+	impl Fixup for JsonSchemaPropsOrBool {
+		fn fixup(&self, spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
+			let mut found = false;
+	
+			for &namespace in &["v1beta1", "v1"] {
+				let definition_path = crate::swagger20::DefinitionPath(format!("io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.{}.JSONSchemaPropsOrBool", namespace));
+	
+				if let Some(definition) = spec.definitions.get_mut(&definition_path) {
+					if !matches!(definition.kind, crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::JsonSchemaPropsOrBool(_))) {
+						definition.kind = crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::JsonSchemaPropsOrBool(namespace));
+						found = true;
+					}
 				}
+			}
+	
+			if found {
+				Ok(())
+			}
+			else {
+				Err("never applied JSONSchemaPropsOrBool override".into())
 			}
 		}
 
-		if found {
-			Ok(())
-		}
-		else {
-			Err("never applied JSONSchemaPropsOrBool override".into())
+		fn requires_client_generation(&self) -> bool {
+			false
 		}
 	}
 
-	pub(crate) fn json_schema_props_or_string_array(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
-		let mut found = false;
+	pub(crate) struct JsonSchemaPropsOrStringArray;
 
-		for &namespace in &["v1beta1", "v1"] {
-			let definition_path = crate::swagger20::DefinitionPath(format!("io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.{}.JSONSchemaPropsOrStringArray", namespace));
-
-			if let Some(definition) = spec.definitions.get_mut(&definition_path) {
-				if !matches!(definition.kind, crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::JsonSchemaPropsOrStringArray(_))) {
-					definition.kind = crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::JsonSchemaPropsOrStringArray(namespace));
-					found = true;
+	impl Fixup for JsonSchemaPropsOrStringArray {
+		fn fixup(&self, spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
+			let mut found = false;
+	
+			for &namespace in &["v1beta1", "v1"] {
+				let definition_path = crate::swagger20::DefinitionPath(format!("io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.{}.JSONSchemaPropsOrStringArray", namespace));
+	
+				if let Some(definition) = spec.definitions.get_mut(&definition_path) {
+					if !matches!(definition.kind, crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::JsonSchemaPropsOrStringArray(_))) {
+						definition.kind = crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::JsonSchemaPropsOrStringArray(namespace));
+						found = true;
+					}
 				}
+			}
+	
+			if found {
+				Ok(())
+			}
+			else {
+				Err("never applied JSONSchemaPropsOrStringArray override".into())
 			}
 		}
 
-		if found {
-			Ok(())
-		}
-		else {
-			Err("never applied JSONSchemaPropsOrStringArray override".into())
+		fn requires_client_generation(&self) -> bool {
+			false
 		}
 	}
 }
@@ -76,134 +104,158 @@ pub(crate) mod json_ty {
 // delete and delete-collection API operations.
 //
 // The original `DeleteOptions` type is still kept since it's used as a field of `io.k8s.api.policy.v1beta1.Eviction`
-pub(crate) fn create_delete_optional(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
-	let delete_options_schema =
-		spec.definitions.get(&crate::swagger20::DefinitionPath("io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions".to_owned()))
-		.ok_or("could not find io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions")?;
-	let delete_options_properties =
-		if let crate::swagger20::SchemaKind::Properties(properties) = &delete_options_schema.kind {
-			properties
-		}
-		else {
-			return Err("io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions is not a SchemaKind::Properties".into());
-		};
-	let delete_optional_properties = delete_options_properties.iter().map(|(name, (schema, _))| (name.clone(), schema.clone())).collect();
+pub(crate) struct CreateDeleteOptional;
 
-	spec.definitions.insert(crate::swagger20::DefinitionPath("io.k8s.DeleteOptional".to_owned()), crate::swagger20::Schema {
-		description: Some("Common parameters for all delete and delete-collection operations.".to_owned()),
-		kind: crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::DeleteOptional(delete_optional_properties)),
-		kubernetes_group_kind_versions: vec![],
-		list_kind: None,
-	});
-
-	Ok(())
-}
-
-// This fixup extracts the common optional parameters of some operations into common types.
-pub(crate) fn create_optionals(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
-	const OPTIONALS: &[(
-		&str,
-		&str,
-		crate::swagger20::KubernetesAction,
-		fn(std::collections::BTreeMap<crate::swagger20::PropertyName, crate::swagger20::Schema>) -> crate::swagger20::Type,
-	)] = &[
-		("create", "io.k8s.CreateOptional", crate::swagger20::KubernetesAction::Post, crate::swagger20::Type::CreateOptional),
-		("patch", "io.k8s.PatchOptional", crate::swagger20::KubernetesAction::Patch, crate::swagger20::Type::PatchOptional),
-		("replace", "io.k8s.ReplaceOptional", crate::swagger20::KubernetesAction::Put, crate::swagger20::Type::ReplaceOptional),
-	];
-
-	for &(description, type_name, kubernetes_action, ty) in OPTIONALS {
-		let mut optional_parameters: Option<std::collections::HashSet<String>> = None;
-		let mut optional_definition: std::collections::BTreeMap<crate::swagger20::PropertyName, crate::swagger20::Schema> = Default::default();
-
-		let optional_parameter = std::sync::Arc::new(crate::swagger20::Parameter {
-			location: crate::swagger20::ParameterLocation::Query,
-			name: "optional".to_owned(),
-			required: true,
-			schema: crate::swagger20::Schema {
-				description: Some("Optional parameters. Use `Default::default()` to not pass any.".to_owned()),
-				kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath {
-					path: type_name.to_owned(),
-					can_be_default: None,
-				}),
-				kubernetes_group_kind_versions: vec![],
-				list_kind: None,
-			},
-		});
-
-		for operation in &mut spec.operations {
-			if operation.kubernetes_action != Some(kubernetes_action) {
-				continue;
+impl Fixup for CreateDeleteOptional {
+	fn fixup(&self, spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
+		let delete_options_schema =
+			spec.definitions.get(&crate::swagger20::DefinitionPath("io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions".to_owned()))
+			.ok_or("could not find io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions")?;
+		let delete_options_properties =
+			if let crate::swagger20::SchemaKind::Properties(properties) = &delete_options_schema.kind {
+				properties
 			}
-
-			if !operation.id.starts_with(description) {
-				return Err(format!(
-					"operation {} has action {:?} but isn't a {} operation",
-					operation.id, operation.kubernetes_action, description).into());
-			}
-
-			{
-				let optional_parameters =
-					&*optional_parameters
-					.get_or_insert_with(||
-						operation.parameters.iter()
-						.filter_map(|p| if p.required { None } else { Some(p.name.clone()) })
-						.collect());
-
-				for expected_parameter_name in optional_parameters {
-					let expected_parameter =
-						if let Some(expected_parameter) = operation.parameters.iter().find(|p| p.name == *expected_parameter_name && !p.required) {
-							&**expected_parameter
-						}
-						else {
-							return Err(format!(
-								"operation {} is a {} operation but doesn't have a {} parameter",
-								operation.id, description, expected_parameter_name).into());
-						};
-
-					optional_definition
-						.entry(crate::swagger20::PropertyName(expected_parameter_name.clone()))
-						.or_insert_with(|| expected_parameter.schema.clone());
-				}
-
-				for parameter in &operation.parameters {
-					if !parameter.required && !optional_parameters.contains(&*parameter.name) {
-						return Err(format!("operation {} contains unexpected optional parameter {}", operation.id, parameter.name).into());
-					}
-				}
-			}
-
-			operation.parameters =
-				operation.parameters.drain(..)
-				.filter(|p| p.required)
-				.chain(std::iter::once(optional_parameter.clone()))
-				.collect();
-		}
-
-		if optional_definition.is_empty() {
-			return Err(format!("never found any {} operations", description).into());
-		}
-
-		spec.definitions.insert(crate::swagger20::DefinitionPath(type_name.to_string()), crate::swagger20::Schema {
-			description: Some(format!("Common parameters for all {} operations.", description)),
-			kind: crate::swagger20::SchemaKind::Ty(ty(optional_definition)),
+			else {
+				return Err("io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions is not a SchemaKind::Properties".into());
+			};
+		let delete_optional_properties = delete_options_properties.iter().map(|(name, (schema, _))| (name.clone(), schema.clone())).collect();
+	
+		spec.definitions.insert(crate::swagger20::DefinitionPath("io.k8s.DeleteOptional".to_owned()), crate::swagger20::Schema {
+			description: Some("Common parameters for all delete and delete-collection operations.".to_owned()),
+			kind: crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::DeleteOptional(delete_optional_properties)),
 			kubernetes_group_kind_versions: vec![],
 			list_kind: None,
 		});
+
+		Ok(())
 	}
 
-	Ok(())
+	fn requires_client_generation(&self) -> bool {
+		false
+	}
+}
+
+// This fixup extracts the common optional parameters of some operations into common types.
+pub(crate) struct CreateOptionals;
+
+impl Fixup for CreateOptionals {
+	fn fixup(&self, spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
+		const OPTIONALS: &[(
+			&str,
+			&str,
+			crate::swagger20::KubernetesAction,
+			fn(std::collections::BTreeMap<crate::swagger20::PropertyName, crate::swagger20::Schema>) -> crate::swagger20::Type,
+		)] = &[
+			("create", "io.k8s.CreateOptional", crate::swagger20::KubernetesAction::Post, crate::swagger20::Type::CreateOptional),
+			("patch", "io.k8s.PatchOptional", crate::swagger20::KubernetesAction::Patch, crate::swagger20::Type::PatchOptional),
+			("replace", "io.k8s.ReplaceOptional", crate::swagger20::KubernetesAction::Put, crate::swagger20::Type::ReplaceOptional),
+		];
+	
+		for &(description, type_name, kubernetes_action, ty) in OPTIONALS {
+			let mut optional_parameters: Option<std::collections::HashSet<String>> = None;
+			let mut optional_definition: std::collections::BTreeMap<crate::swagger20::PropertyName, crate::swagger20::Schema> = Default::default();
+	
+			let optional_parameter = std::sync::Arc::new(crate::swagger20::Parameter {
+				location: crate::swagger20::ParameterLocation::Query,
+				name: "optional".to_owned(),
+				required: true,
+				schema: crate::swagger20::Schema {
+					description: Some("Optional parameters. Use `Default::default()` to not pass any.".to_owned()),
+					kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath {
+						path: type_name.to_owned(),
+						can_be_default: None,
+					}),
+					kubernetes_group_kind_versions: vec![],
+					list_kind: None,
+				},
+			});
+	
+			for operation in &mut spec.operations {
+				if operation.kubernetes_action != Some(kubernetes_action) {
+					continue;
+				}
+	
+				if !operation.id.starts_with(description) {
+					return Err(format!(
+						"operation {} has action {:?} but isn't a {} operation",
+						operation.id, operation.kubernetes_action, description).into());
+				}
+	
+				{
+					let optional_parameters =
+						&*optional_parameters
+						.get_or_insert_with(||
+							operation.parameters.iter()
+							.filter_map(|p| if p.required { None } else { Some(p.name.clone()) })
+							.collect());
+	
+					for expected_parameter_name in optional_parameters {
+						let expected_parameter =
+							if let Some(expected_parameter) = operation.parameters.iter().find(|p| p.name == *expected_parameter_name && !p.required) {
+								&**expected_parameter
+							}
+							else {
+								return Err(format!(
+									"operation {} is a {} operation but doesn't have a {} parameter",
+									operation.id, description, expected_parameter_name).into());
+							};
+	
+						optional_definition
+							.entry(crate::swagger20::PropertyName(expected_parameter_name.clone()))
+							.or_insert_with(|| expected_parameter.schema.clone());
+					}
+	
+					for parameter in &operation.parameters {
+						if !parameter.required && !optional_parameters.contains(&*parameter.name) {
+							return Err(format!("operation {} contains unexpected optional parameter {}", operation.id, parameter.name).into());
+						}
+					}
+				}
+	
+				operation.parameters =
+					operation.parameters.drain(..)
+					.filter(|p| p.required)
+					.chain(std::iter::once(optional_parameter.clone()))
+					.collect();
+			}
+	
+			if optional_definition.is_empty() {
+				return Err(format!("never found any {} operations", description).into());
+			}
+	
+			spec.definitions.insert(crate::swagger20::DefinitionPath(type_name.to_string()), crate::swagger20::Schema {
+				description: Some(format!("Common parameters for all {} operations.", description)),
+				kind: crate::swagger20::SchemaKind::Ty(ty(optional_definition)),
+				kubernetes_group_kind_versions: vec![],
+				list_kind: None,
+			});
+		}
+	
+		Ok(())	
+	}
+
+	fn requires_client_generation(&self) -> bool {
+		true
+	}
 }
 
 // Annotate the `patch` type as `swagger20::Type::Patch` for special codegen.
-pub(crate) fn patch(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
-	let definition_path = crate::swagger20::DefinitionPath("io.k8s.apimachinery.pkg.apis.meta.v1.Patch".to_owned());
-	if let Some(definition) = spec.definitions.get_mut(&definition_path) {
-		definition.kind = crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::Patch);
-		return Ok(());
-	}
+pub(crate) struct Patch;
 
-	Err("never applied Patch override".into())
+impl Fixup for Patch {
+    fn fixup(&self, spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
+		let definition_path = crate::swagger20::DefinitionPath("io.k8s.apimachinery.pkg.apis.meta.v1.Patch".to_owned());
+		if let Some(definition) = spec.definitions.get_mut(&definition_path) {
+			definition.kind = crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::Patch);
+			return Ok(());
+		}
+	
+		Err("never applied Patch override".into())
+    }
+
+	fn requires_client_generation(&self) -> bool {
+		false
+	}
 }
 
 // The spec describes delete-collection operations as having query parameters that are a union of parameters of list and delete operations.
@@ -211,96 +263,113 @@ pub(crate) fn patch(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Erro
 // the `separate_watch_from_list_operations` fixup below.
 //
 // So replace these path=query parameters with `ListOptional` and `DeleteOptions` parameters.
-pub(crate) fn remove_delete_collection_operations_query_parameters(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
-	let mut found = false;
+pub(crate) struct RemoveDeleteCollectionOperationsQueryParameters;
 
-	for operation in &mut spec.operations {
-		if operation.kubernetes_action == Some(crate::swagger20::KubernetesAction::DeleteCollection) {
-			operation.parameters = operation.parameters.drain(..).filter(|p| p.location == crate::swagger20::ParameterLocation::Path).collect();
-			operation.parameters.push(std::sync::Arc::new(crate::swagger20::Parameter {
-				location: crate::swagger20::ParameterLocation::Body,
-				name: "deleteOptional".to_owned(),
-				required: true,
-				schema: crate::swagger20::Schema {
-					description: Some("Delete options. Use `Default::default()` to not pass any.".to_owned()),
-					kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath {
-						path: "io.k8s.DeleteOptional".to_owned(),
-						can_be_default: None,
-					}),
-					kubernetes_group_kind_versions: vec![],
-					list_kind: None,
-				},
-			}));
-			operation.parameters.push(std::sync::Arc::new(crate::swagger20::Parameter {
-				location: crate::swagger20::ParameterLocation::Query,
-				name: "listOptional".to_owned(),
-				required: true,
-				schema: crate::swagger20::Schema {
-					description: Some("List options. Use `Default::default()` to not pass any.".to_owned()),
-					kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath {
-						path: "io.k8s.ListOptional".to_owned(),
-						can_be_default: None,
-					}),
-					kubernetes_group_kind_versions: vec![],
-					list_kind: None,
-				},
-			}));
+impl Fixup for RemoveDeleteCollectionOperationsQueryParameters {
+	fn fixup(&self, spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
+		let mut found = false;
 
-			found = true;
+		for operation in &mut spec.operations {
+			if operation.kubernetes_action == Some(crate::swagger20::KubernetesAction::DeleteCollection) {
+				operation.parameters = operation.parameters.drain(..).filter(|p| p.location == crate::swagger20::ParameterLocation::Path).collect();
+				operation.parameters.push(std::sync::Arc::new(crate::swagger20::Parameter {
+					location: crate::swagger20::ParameterLocation::Body,
+					name: "deleteOptional".to_owned(),
+					required: true,
+					schema: crate::swagger20::Schema {
+						description: Some("Delete options. Use `Default::default()` to not pass any.".to_owned()),
+						kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath {
+							path: "io.k8s.DeleteOptional".to_owned(),
+							can_be_default: None,
+						}),
+						kubernetes_group_kind_versions: vec![],
+						list_kind: None,
+					},
+				}));
+				operation.parameters.push(std::sync::Arc::new(crate::swagger20::Parameter {
+					location: crate::swagger20::ParameterLocation::Query,
+					name: "listOptional".to_owned(),
+					required: true,
+					schema: crate::swagger20::Schema {
+						description: Some("List options. Use `Default::default()` to not pass any.".to_owned()),
+						kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath {
+							path: "io.k8s.ListOptional".to_owned(),
+							can_be_default: None,
+						}),
+						kubernetes_group_kind_versions: vec![],
+						list_kind: None,
+					},
+				}));
+
+					found = true;
+			}
+		}
+
+		if found {
+			Ok(())
+		} else {
+			Err("never applied remove-delete-collection-operations-query-parameters fixup".into())
 		}
 	}
 
-	if found {
-		Ok(())
-	}
-	else {
-		Err("never applied remove-delete-collection-operations-query-parameters fixup".into())
+	fn requires_client_generation(&self) -> bool {
+		true
 	}
 }
+
 
 // Delete operations duplicate some of the properties of their path=body `DeleteOptions` parameter with path=query parameters.
 //
 // Remove the path=query parameters and replace the path=body parameter with an `io.k8s.DeleteOptional` parameter.
-pub(crate) fn remove_delete_operations_query_parameters(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
-	let mut found = false;
+pub(crate) struct RemoveDeleteOperationsQueryParameters;
 
-	for operation in &mut spec.operations {
-		if operation.kubernetes_action == Some(crate::swagger20::KubernetesAction::Delete) {
-			if let Some(body_parameter) = operation.parameters.iter().find(|p| p.location == crate::swagger20::ParameterLocation::Body) {
-				if let crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath { path, .. }) = &body_parameter.schema.kind {
-					if path == "io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions" {
-						operation.parameters = operation.parameters.drain(..).filter(|p| p.location == crate::swagger20::ParameterLocation::Path).collect();
-						operation.parameters.push(std::sync::Arc::new(crate::swagger20::Parameter {
-							location: crate::swagger20::ParameterLocation::Body,
-							name: "optional".to_owned(),
-							required: true,
-							schema: crate::swagger20::Schema {
-								description: Some("Optional parameters. Use `Default::default()` to not pass any.".to_owned()),
-								kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath {
-									path: "io.k8s.DeleteOptional".to_owned(),
-									can_be_default: None,
-								}),
-								kubernetes_group_kind_versions: vec![],
-								list_kind: None,
-							},
-						}));
-						found = true;
-						continue;
+impl Fixup for RemoveDeleteOperationsQueryParameters {
+	fn fixup(&self, spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
+		let mut found = false;
+
+		for operation in &mut spec.operations {
+			if operation.kubernetes_action == Some(crate::swagger20::KubernetesAction::Delete) {
+				if let Some(body_parameter) = operation.parameters.iter().find(|p| p.location == crate::swagger20::ParameterLocation::Body) {
+					if let crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath { path, .. }) = &body_parameter.schema.kind {
+						if path == "io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions" {
+							operation.parameters = operation.parameters.drain(..).filter(|p| p.location == crate::swagger20::ParameterLocation::Path).collect();
+							operation.parameters.push(std::sync::Arc::new(crate::swagger20::Parameter {
+								location: crate::swagger20::ParameterLocation::Body,
+								name: "optional".to_owned(),
+								required: true,
+								schema: crate::swagger20::Schema {
+									description: Some("Optional parameters. Use `Default::default()` to not pass any.".to_owned()),
+									kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath {
+										path: "io.k8s.DeleteOptional".to_owned(),
+										can_be_default: None,
+									}),
+									kubernetes_group_kind_versions: vec![],
+									list_kind: None,
+								},
+							}));
+							found = true;
+							continue;
+						}
 					}
-				}
 
-				return Err(format!("DELETE operation {} does not have a DeleteOptions body parameter", operation.id).into());
+					return Err(format!("DELETE operation {} does not have a DeleteOptions body parameter", operation.id).into());
+				}
 			}
+		}
+
+		if found {
+			Ok(())
+		}
+		else {
+			Err("never applied remove-delete-operations-query-parameters fixup".into())
 		}
 	}
 
-	if found {
-		Ok(())
-	}
-	else {
-		Err("never applied remove-delete-operations-query-parameters fixup".into())
+	fn requires_client_generation(&self) -> bool {
+		true
 	}
 }
+
 
 // Some watch and watchlist operations (eg `watchCoreV1NamespacedPod` and `watchCoreV1NamespacedPodList`) are deprecated in favor of the corresponding list operation
 // (eg `listCoreV1NamespacedPod`). The watch operation is equivalent to using the list operation with `watch=true` and `field_selector=...`, and the watchlist operation
@@ -314,433 +383,450 @@ pub(crate) fn remove_delete_operations_query_parameters(spec: &mut crate::swagge
 // with the `watch` parameter set. Thus it's applied even to those list operations which don't have corresponding deprecated watch or watchlist operations.
 //
 // This fixup also synthesizes mod-root-level `ListOptional` and `WatchOptional` types which have the common parameters of all list and watch operations respectively.
-pub(crate) fn separate_watch_from_list_operations(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
-	use std::fmt::Write;
+pub(crate) struct SeparateWatchFromListOperations;
 
-	let mut list_optional_parameters: Option<std::collections::HashSet<String>> = None;
-	let mut list_optional_definition: std::collections::BTreeMap<crate::swagger20::PropertyName, crate::swagger20::Schema> = Default::default();
-	let mut watch_optional_definition: std::collections::BTreeMap<crate::swagger20::PropertyName, crate::swagger20::Schema> = Default::default();
-	let mut list_operations = vec![];
+impl Fixup for SeparateWatchFromListOperations {
+	fn fixup(&self, spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
+		use std::fmt::Write;
 
-	for operation in &mut spec.operations {
-		if operation.kubernetes_action != Some(crate::swagger20::KubernetesAction::List) {
-			continue;
-		}
+		let mut list_optional_parameters: Option<std::collections::HashSet<String>> = None;
+		let mut list_optional_definition: std::collections::BTreeMap<crate::swagger20::PropertyName, crate::swagger20::Schema> = Default::default();
+		let mut watch_optional_definition: std::collections::BTreeMap<crate::swagger20::PropertyName, crate::swagger20::Schema> = Default::default();
+		let mut list_operations = vec![];
 
-		if !operation.id.starts_with("list") {
-			return Err(format!(r#"operation {} is a list operation but doesn't start with "list""#, operation.id).into());
-		}
-
-		let list_optional_parameters =
-			&*list_optional_parameters.get_or_insert_with(|| operation.parameters.iter().map(|p| p.name.clone()).collect());
-
-		for expected_parameter_name in list_optional_parameters {
-			let expected_parameter =
-				if let Some(expected_parameter) = operation.parameters.iter().find(|p| p.name == *expected_parameter_name && !p.required) {
-					&**expected_parameter
-				}
-				else {
-					return Err(format!("operation {} is a list operation but doesn't have a {} parameter", operation.id, expected_parameter_name).into());
-				};
-
-			if expected_parameter_name != "allowWatchBookmarks" && expected_parameter_name != "watch" {
-				list_optional_definition
-					.entry(crate::swagger20::PropertyName(expected_parameter_name.clone()))
-					.or_insert_with(|| expected_parameter.schema.clone());
+		for operation in &mut spec.operations {
+			if operation.kubernetes_action != Some(crate::swagger20::KubernetesAction::List) {
+				continue;
 			}
 
-			if
-				expected_parameter_name != "continue" &&
-				expected_parameter_name != "limit" &&
-				expected_parameter_name != "resourceVersionMatch" &&
-				expected_parameter_name != "watch"
-			{
-				watch_optional_definition
-					.entry(crate::swagger20::PropertyName(expected_parameter_name.clone()))
-					.or_insert_with(|| expected_parameter.schema.clone());
+			if !operation.id.starts_with("list") {
+				return Err(format!(r#"operation {} is a list operation but doesn't start with "list""#, operation.id).into());
 			}
-		}
 
-		for parameter in &operation.parameters {
-			if !parameter.required && !list_optional_parameters.contains(&*parameter.name) {
-				return Err(format!("operation {} contains unexpected optional parameter {}", operation.id, parameter.name).into());
-			}
-		}
+			let list_optional_parameters =
+				&*list_optional_parameters.get_or_insert_with(|| operation.parameters.iter().map(|p| p.name.clone()).collect());
 
-		list_operations.push(operation.id.clone());
-	}
-
-	if list_operations.is_empty() {
-		return Err("never found any list-watch operations".into());
-	}
-
-	spec.definitions.insert(crate::swagger20::DefinitionPath("io.k8s.ListOptional".to_string()), crate::swagger20::Schema {
-		description: Some("Common parameters for all list operations.".to_string()),
-		kind: crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::ListOptional(list_optional_definition)),
-		kubernetes_group_kind_versions: vec![],
-		list_kind: None,
-	});
-
-	spec.definitions.insert(crate::swagger20::DefinitionPath("io.k8s.WatchOptional".to_string()), crate::swagger20::Schema {
-		description: Some("Common parameters for all watch operations.".to_string()),
-		kind: crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::WatchOptional(watch_optional_definition)),
-		kubernetes_group_kind_versions: vec![],
-		list_kind: None,
-	});
-
-	let list_optional_parameter = std::sync::Arc::new(crate::swagger20::Parameter {
-		location: crate::swagger20::ParameterLocation::Query,
-		name: "optional".to_owned(),
-		required: true,
-		schema: crate::swagger20::Schema {
-			description: Some("Optional parameters. Use `Default::default()` to not pass any.".to_owned()),
-			kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath {
-				path: "io.k8s.ListOptional".to_owned(),
-				can_be_default: None,
-			}),
-			kubernetes_group_kind_versions: vec![],
-			list_kind: None,
-		},
-	});
-
-	let watch_optional_parameter = std::sync::Arc::new(crate::swagger20::Parameter {
-		location: crate::swagger20::ParameterLocation::Query,
-		name: "optional".to_owned(),
-		required: true,
-		schema: crate::swagger20::Schema {
-			description: Some("Optional parameters. Use `Default::default()` to not pass any.".to_owned()),
-			kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath {
-				path: "io.k8s.WatchOptional".to_owned(),
-				can_be_default: None,
-			}),
-			kubernetes_group_kind_versions: vec![],
-			list_kind: None,
-		},
-	});
-
-	let mut converted_watch_operations: std::collections::HashSet<_> = Default::default();
-
-	for list_operation_id in list_operations {
-		let watch_operation_id = list_operation_id.replacen("list", "watch", 1);
-		let watch_list_operation_id =
-			if watch_operation_id.ends_with("ForAllNamespaces") {
-				watch_operation_id[..(watch_operation_id.len() - "ForAllNamespaces".len())].to_owned() + "ListForAllNamespaces"
-			}
-			else {
-				watch_operation_id.clone() + "List"
-			};
-
-		if let Some(watch_operation_index) = spec.operations.iter().position(|o| o.id == watch_operation_id) {
-			spec.operations.swap_remove(watch_operation_index);
-		}
-		if let Some(watch_list_operation_index) = spec.operations.iter().position(|o| o.id == watch_list_operation_id) {
-			spec.operations.swap_remove(watch_list_operation_index);
-		}
-
-		let (original_list_operation_index, original_list_operation) = spec.operations.iter().enumerate().find(|(_, o)| o.id == list_operation_id).unwrap();
-
-		let mut base_description = original_list_operation.description.as_ref().map_or("", std::ops::Deref::deref).to_owned();
-		if !base_description.is_empty() {
-			writeln!(base_description)?;
-			writeln!(base_description)?;
-		}
-
-		let mut list_operation = crate::swagger20::Operation {
-			description: Some({
-				let mut description = base_description.clone();
-				writeln!(description, "This operation only supports listing all items of this type.")?;
-				description
-			}),
-			..original_list_operation.clone()
-		};
-		list_operation.parameters =
-			list_operation.parameters.into_iter()
-			.filter(|parameter| parameter.required)
-			.chain(std::iter::once(list_optional_parameter.clone()))
-			.collect();
-
-		let mut watch_operation = crate::swagger20::Operation {
-			description: Some({
-				let mut description = base_description.clone();
-				writeln!(description, "This operation only supports watching one item, or a list of items, of this type for changes.")?;
-				description
-			}),
-			id: watch_operation_id.clone(),
-			kubernetes_action: Some(crate::swagger20::KubernetesAction::Watch),
-			..original_list_operation.clone()
-		};
-		watch_operation.parameters =
-			watch_operation.parameters.into_iter()
-			.filter(|parameter| parameter.required)
-			.chain(std::iter::once(watch_optional_parameter.clone()))
-			.collect();
-		if let crate::swagger20::OperationResponses::Map(responses) = &mut watch_operation.responses {
-			responses.insert(http::StatusCode::OK, crate::swagger20::Schema {
-				description: Some("OK".to_owned()),
-				kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath {
-					path: "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent".to_owned(),
-					can_be_default: None,
-				}),
-				kubernetes_group_kind_versions: vec![],
-				list_kind: None,
-			});
-		}
-		else {
-			unreachable!();
-		}
-
-		spec.operations[original_list_operation_index] = list_operation;
-		spec.operations.push(watch_operation);
-		converted_watch_operations.insert(watch_operation_id);
-	}
-
-	for operation in &spec.operations {
-		if let Some(crate::swagger20::KubernetesAction::Watch | crate::swagger20::KubernetesAction::WatchList) = operation.kubernetes_action {
-			if !converted_watch_operations.contains(&operation.id) {
-				return Err(format!("found a watch operation that wasn't synthesized from a list operation: {:?}", operation).into());
-			}
-		}
-	}
-
-	Ok(())
-}
-
-// Annotate the `WatchEvent` type as `swagger20::Type::WatchEvent` for special codegen.
-pub(crate) fn watch_event(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
-	use std::fmt::Write;
-
-	let definition_path = crate::swagger20::DefinitionPath("io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent".to_owned());
-	if let Some(mut definition) = spec.definitions.remove(&definition_path) {
-		if let crate::swagger20::SchemaKind::Properties(mut properties) = definition.kind {
-			let object_property_name = crate::swagger20::PropertyName("object".to_owned());
-			if let Some((object_property, true)) = properties.remove(&object_property_name) {
-				if let crate::swagger20::SchemaKind::Ref(raw_extension_ref_path) = object_property.kind {
-					definition.kind = crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::WatchEvent(raw_extension_ref_path));
-					if let Some(type_description) = &mut definition.description {
-						if let Some(property_description) = &object_property.description {
-							writeln!(type_description)?;
-							writeln!(type_description)?;
-							writeln!(type_description, "{}", property_description)?;
-						}
+			for expected_parameter_name in list_optional_parameters {
+				let expected_parameter =
+					if let Some(expected_parameter) = operation.parameters.iter().find(|p| p.name == *expected_parameter_name && !p.required) {
+						&**expected_parameter
 					}
-					spec.definitions.insert(definition_path, definition);
-					return Ok(());
-				}
-			}
-		}
-	}
+					else {
+						return Err(format!("operation {} is a list operation but doesn't have a {} parameter", operation.id, expected_parameter_name).into());
+					};
 
-	Err("never applied WatchEvent override".into())
-}
-
-// Define the `swagger20::Type::ListDef` list type, and replace all list types in the spec with `swagger20::Type::ListRef` for special codegen.
-pub(crate) fn list(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
-	let items_property_name = crate::swagger20::PropertyName("items".to_owned());
-	let metadata_property_name = crate::swagger20::PropertyName("metadata".to_owned());
-
-	let mut list_definition_paths = vec![];
-	let mut list_properties = None;
-
-	for (definition_path, definition) in &spec.definitions {
-		if !definition_path.ends_with("List") {
-			continue;
-		}
-
-		let properties =
-			if let crate::swagger20::SchemaKind::Properties(properties) = &definition.kind {
-				properties
-			}
-			else {
-				continue;
-			};
-
-		if !matches!(properties.get(&items_property_name), Some((_, true))) {
-			continue;
-		}
-
-		let metadata_schema =
-			if let Some((metadata_schema, _)) = properties.get(&metadata_property_name) {
-				metadata_schema
-			}
-			else {
-				continue;
-			};
-
-		let metadata_ref_path =
-			if let crate::swagger20::SchemaKind::Ref(metadata_ref_path) = &metadata_schema.kind {
-				metadata_ref_path
-			}
-			else {
-				continue;
-			};
-		if !metadata_ref_path.path.ends_with(".ListMeta") {
-			continue;
-		}
-
-		let item_schema =
-			if let
-				Some((
-					crate::swagger20::Schema {
-						kind: crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::Array { items: item_schema }),
-						..
-					},
-					true,
-				)) = properties.get(&items_property_name)
-			{
-				item_schema
-			}
-			else {
-				return Err(format!("definition {} looks like a list but doesn't have an items property", definition_path).into());
-			};
-
-		let (item_ref_path, list_kind) =
-			if let crate::swagger20::SchemaKind::Ref(item_ref_path) = &item_schema.kind {
-				let item_schema =
-					spec.definitions.get(&crate::swagger20::DefinitionPath(item_ref_path.path.clone()))
-					.ok_or_else(|| format!("definition {} looks like a list but its item's definition does not exist in the spec", definition_path))?;
-
-				let item_kubernetes_group_kind_version = match &item_schema.kubernetes_group_kind_versions[..] {
-					[group_kind_version] => group_kind_version,
-					_ => return Err(format!(
-						"definition {} looks like a list but its item's definition does not have a single group-version-kind",
-						definition_path).into()),
-				};
-
-				let list_kubernetes_group_kind_version = match &definition.kubernetes_group_kind_versions[..] {
-					[group_kind_version] => group_kind_version,
-					_ => return Err(format!(
-						"definition {} looks like a list but it does not have a single group-version-kind",
-						definition_path).into()),
-				};
-
-				let item_gkv_corresponds_to_list_gkv =
-					list_kubernetes_group_kind_version.group == item_kubernetes_group_kind_version.group &&
-					list_kubernetes_group_kind_version.version == item_kubernetes_group_kind_version.version &&
-					list_kubernetes_group_kind_version.kind == format!("{}List", item_kubernetes_group_kind_version.kind);
-				if !item_gkv_corresponds_to_list_gkv {
-					return Err(format!(
-						"defintion {} looks like a list but its group-version-kind does not correspond to its item's group-version-kind", definition_path).into());
+				if expected_parameter_name != "allowWatchBookmarks" && expected_parameter_name != "watch" {
+					list_optional_definition
+						.entry(crate::swagger20::PropertyName(expected_parameter_name.clone()))
+						.or_insert_with(|| expected_parameter.schema.clone());
 				}
 
-				(item_ref_path.clone(), list_kubernetes_group_kind_version.kind.clone())
+				if
+					expected_parameter_name != "continue" &&
+					expected_parameter_name != "limit" &&
+					expected_parameter_name != "resourceVersionMatch" &&
+					expected_parameter_name != "watch"
+				{
+					watch_optional_definition
+						.entry(crate::swagger20::PropertyName(expected_parameter_name.clone()))
+						.or_insert_with(|| expected_parameter.schema.clone());
+				}
 			}
-			else {
-				return Err(format!("definition {} looks like a list but its items property is not a ref", definition_path).into());
-			};
 
-		list_definition_paths.push((definition_path.clone(), item_ref_path, list_kind));
-
-		if let Some((_, list_property_names)) = &list_properties {
-			let property_names: std::collections::BTreeSet<_> = properties.keys().cloned().collect();
-			if &property_names != list_property_names {
-				return Err(format!("Definition {} looks like a list but doesn't have the expected properties: {:?}", definition_path, properties).into());
+			for parameter in &operation.parameters {
+				if !parameter.required && !list_optional_parameters.contains(&*parameter.name) {
+					return Err(format!("operation {} contains unexpected optional parameter {}", operation.id, parameter.name).into());
+				}
 			}
+
+			list_operations.push(operation.id.clone());
 		}
-		else {
-			let mut properties = properties.clone();
-			properties.insert(
-				items_property_name.clone(),
-				(
-					crate::swagger20::Schema {
-						description: Some("List of objects".to_owned()),
-						kind: crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::Array {
-							items: Box::new(crate::swagger20::Schema {
-								description: None,
-								kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath {
-									path: "T".to_owned(),
-									can_be_default: None,
-								}),
-								kubernetes_group_kind_versions: vec![],
-								list_kind: None,
-							}),
-						}),
-						kubernetes_group_kind_versions: vec![],
-						list_kind: None,
-					},
-					true,
-				));
-			let property_names: std::collections::BTreeSet<_> = properties.keys().cloned().collect();
 
-			list_properties = Some((metadata_schema.kind.clone(), property_names));
+		if list_operations.is_empty() {
+			return Err("never found any list-watch operations".into());
 		}
-	}
 
-	let (metadata_schema_kind, _) = list_properties.ok_or("did not find any types that looked like a list")?;
-
-
-	// Synthesize `k8s_openapi::List<T>`
-
-	spec.definitions.insert(
-		crate::swagger20::DefinitionPath("io.k8s.List".to_owned()),
-		crate::swagger20::Schema {
-			description: Some("List is a list of resources.".to_owned()),
-			kind: crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::ListDef { metadata: Box::new(metadata_schema_kind) }),
+		spec.definitions.insert(crate::swagger20::DefinitionPath("io.k8s.ListOptional".to_string()), crate::swagger20::Schema {
+			description: Some("Common parameters for all list operations.".to_string()),
+			kind: crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::ListOptional(list_optional_definition)),
 			kubernetes_group_kind_versions: vec![],
 			list_kind: None,
 		});
 
+		spec.definitions.insert(crate::swagger20::DefinitionPath("io.k8s.WatchOptional".to_string()), crate::swagger20::Schema {
+			description: Some("Common parameters for all watch operations.".to_string()),
+			kind: crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::WatchOptional(watch_optional_definition)),
+			kubernetes_group_kind_versions: vec![],
+			list_kind: None,
+		});
 
-	// Remove all list types
+		let list_optional_parameter = std::sync::Arc::new(crate::swagger20::Parameter {
+			location: crate::swagger20::ParameterLocation::Query,
+			name: "optional".to_owned(),
+			required: true,
+			schema: crate::swagger20::Schema {
+				description: Some("Optional parameters. Use `Default::default()` to not pass any.".to_owned()),
+				kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath {
+					path: "io.k8s.ListOptional".to_owned(),
+					can_be_default: None,
+				}),
+				kubernetes_group_kind_versions: vec![],
+				list_kind: None,
+			},
+		});
 
-	for (definition_path, item_ref_path, list_kind) in &list_definition_paths {
-		let item_definition = spec.definitions.get_mut(&crate::swagger20::DefinitionPath(item_ref_path.path.clone())).unwrap();
-		item_definition.list_kind = Some(list_kind.clone());
+		let watch_optional_parameter = std::sync::Arc::new(crate::swagger20::Parameter {
+			location: crate::swagger20::ParameterLocation::Query,
+			name: "optional".to_owned(),
+			required: true,
+			schema: crate::swagger20::Schema {
+				description: Some("Optional parameters. Use `Default::default()` to not pass any.".to_owned()),
+				kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath {
+					path: "io.k8s.WatchOptional".to_owned(),
+					can_be_default: None,
+				}),
+				kubernetes_group_kind_versions: vec![],
+				list_kind: None,
+			},
+		});
 
-		let _ = spec.definitions.remove(definition_path);
-	}
+		let mut converted_watch_operations: std::collections::HashSet<_> = Default::default();
 
-
-	// Replace references to all list types with refs to `k8s_openapi::List<T>`
-
-	for (definition_path, item_ref_path, _) in list_definition_paths {
-		for definition in spec.definitions.values_mut() {
-			if let crate::swagger20::SchemaKind::Properties(properties) = &mut definition.kind {
-				for (field_value_schema, _) in properties.values_mut() {
-					let field_value_schema_kind = &mut field_value_schema.kind;
-					if let crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath { path, .. }) = field_value_schema_kind {
-						if path == &definition_path.0 {
-							*field_value_schema_kind = crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::ListRef {
-								items: Box::new(crate::swagger20::SchemaKind::Ref(item_ref_path.clone())),
-							});
-						}
-					}
+		for list_operation_id in list_operations {
+			let watch_operation_id = list_operation_id.replacen("list", "watch", 1);
+			let watch_list_operation_id =
+				if watch_operation_id.ends_with("ForAllNamespaces") {
+					watch_operation_id[..(watch_operation_id.len() - "ForAllNamespaces".len())].to_owned() + "ListForAllNamespaces"
 				}
+				else {
+					watch_operation_id.clone() + "List"
+				};
+	
+			if let Some(watch_operation_index) = spec.operations.iter().position(|o| o.id == watch_operation_id) {
+				spec.operations.swap_remove(watch_operation_index);
 			}
-		}
-
-		for operation in &mut spec.operations {
-			if let crate::swagger20::OperationResponses::Map(responses) = &mut operation.responses {
-				for response in responses.values_mut() {
-					let response_schema_kind = &mut response.kind;
-					if let crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath { path, .. }) = response_schema_kind {
-						if path == &definition_path.0 {
-							*response_schema_kind = crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::ListRef {
-								items: Box::new(crate::swagger20::SchemaKind::Ref(item_ref_path.clone())),
-							});
-						}
-					}
-				}
+			if let Some(watch_list_operation_index) = spec.operations.iter().position(|o| o.id == watch_list_operation_id) {
+				spec.operations.swap_remove(watch_list_operation_index);
+			}
+	
+			let (original_list_operation_index, original_list_operation) = spec.operations.iter().enumerate().find(|(_, o)| o.id == list_operation_id).unwrap();
+	
+			let mut base_description = original_list_operation.description.as_ref().map_or("", std::ops::Deref::deref).to_owned();
+			if !base_description.is_empty() {
+				writeln!(base_description)?;
+				writeln!(base_description)?;
+			}
+	
+			let mut list_operation = crate::swagger20::Operation {
+				description: Some({
+					let mut description = base_description.clone();
+					writeln!(description, "This operation only supports listing all items of this type.")?;
+					description
+				}),
+				..original_list_operation.clone()
+			};
+			list_operation.parameters =
+				list_operation.parameters.into_iter()
+				.filter(|parameter| parameter.required)
+				.chain(std::iter::once(list_optional_parameter.clone()))
+				.collect();
+	
+			let mut watch_operation = crate::swagger20::Operation {
+				description: Some({
+					let mut description = base_description.clone();
+					writeln!(description, "This operation only supports watching one item, or a list of items, of this type for changes.")?;
+					description
+				}),
+				id: watch_operation_id.clone(),
+				kubernetes_action: Some(crate::swagger20::KubernetesAction::Watch),
+				..original_list_operation.clone()
+			};
+			watch_operation.parameters =
+				watch_operation.parameters.into_iter()
+				.filter(|parameter| parameter.required)
+				.chain(std::iter::once(watch_optional_parameter.clone()))
+				.collect();
+			if let crate::swagger20::OperationResponses::Map(responses) = &mut watch_operation.responses {
+				responses.insert(http::StatusCode::OK, crate::swagger20::Schema {
+					description: Some("OK".to_owned()),
+					kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath {
+						path: "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent".to_owned(),
+						can_be_default: None,
+					}),
+					kubernetes_group_kind_versions: vec![],
+					list_kind: None,
+				});
 			}
 			else {
 				unreachable!();
 			}
+	
+			spec.operations[original_list_operation_index] = list_operation;
+			spec.operations.push(watch_operation);
+			converted_watch_operations.insert(watch_operation_id);
 		}
+	
+		for operation in &spec.operations {
+			if let Some(crate::swagger20::KubernetesAction::Watch | crate::swagger20::KubernetesAction::WatchList) = operation.kubernetes_action {
+				if !converted_watch_operations.contains(&operation.id) {
+					return Err(format!("found a watch operation that wasn't synthesized from a list operation: {:?}", operation).into());
+				}
+			}
+		}
+	
+		Ok(())
 	}
 
-	Ok(())
+	fn requires_client_generation(&self) -> bool {
+		true
+	}
+}
+
+// Annotate the `WatchEvent` type as `swagger20::Type::WatchEvent` for special codegen.
+pub(crate) struct WatchEvent;
+
+impl Fixup for WatchEvent {
+	fn fixup(&self, spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
+		use std::fmt::Write;
+
+		let definition_path = crate::swagger20::DefinitionPath("io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent".to_owned());
+		if let Some(mut definition) = spec.definitions.remove(&definition_path) {
+			if let crate::swagger20::SchemaKind::Properties(mut properties) = definition.kind {
+				let object_property_name = crate::swagger20::PropertyName("object".to_owned());
+				if let Some((object_property, true)) = properties.remove(&object_property_name) {
+					if let crate::swagger20::SchemaKind::Ref(raw_extension_ref_path) = object_property.kind {
+						definition.kind = crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::WatchEvent(raw_extension_ref_path));
+						if let Some(type_description) = &mut definition.description {
+							if let Some(property_description) = &object_property.description {
+								writeln!(type_description)?;
+								writeln!(type_description)?;
+								writeln!(type_description, "{}", property_description)?;
+							}
+						}
+						spec.definitions.insert(definition_path, definition);
+						return Ok(());
+					}
+				}
+			}
+		}
+	
+		Err("never applied WatchEvent override".into())
+	}
+
+	fn requires_client_generation(&self) -> bool {
+		false
+	}
+}
+
+// Define the `swagger20::Type::ListDef` list type, and replace all list types in the spec with `swagger20::Type::ListRef` for special codegen.
+pub(crate) struct List;
+
+impl Fixup for List {
+    fn fixup(&self, spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
+		let items_property_name = crate::swagger20::PropertyName("items".to_owned());
+		let metadata_property_name = crate::swagger20::PropertyName("metadata".to_owned());
+	
+		let mut list_definition_paths = vec![];
+		let mut list_properties = None;
+	
+		for (definition_path, definition) in &spec.definitions {
+			if !definition_path.ends_with("List") {
+				continue;
+			}
+	
+			let properties =
+				if let crate::swagger20::SchemaKind::Properties(properties) = &definition.kind {
+					properties
+				}
+				else {
+					continue;
+				};
+	
+			if !matches!(properties.get(&items_property_name), Some((_, true))) {
+				continue;
+			}
+	
+			let metadata_schema =
+				if let Some((metadata_schema, _)) = properties.get(&metadata_property_name) {
+					metadata_schema
+				}
+				else {
+					continue;
+				};
+	
+			let metadata_ref_path =
+				if let crate::swagger20::SchemaKind::Ref(metadata_ref_path) = &metadata_schema.kind {
+					metadata_ref_path
+				}
+				else {
+					continue;
+				};
+			if !metadata_ref_path.path.ends_with(".ListMeta") {
+				continue;
+			}
+	
+			let item_schema =
+				if let
+					Some((
+						crate::swagger20::Schema {
+							kind: crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::Array { items: item_schema }),
+							..
+						},
+						true,
+					)) = properties.get(&items_property_name)
+				{
+					item_schema
+				}
+				else {
+					return Err(format!("definition {} looks like a list but doesn't have an items property", definition_path).into());
+				};
+	
+			let (item_ref_path, list_kind) =
+				if let crate::swagger20::SchemaKind::Ref(item_ref_path) = &item_schema.kind {
+					let item_schema =
+						spec.definitions.get(&crate::swagger20::DefinitionPath(item_ref_path.path.clone()))
+						.ok_or_else(|| format!("definition {} looks like a list but its item's definition does not exist in the spec", definition_path))?;
+	
+					let item_kubernetes_group_kind_version = match &item_schema.kubernetes_group_kind_versions[..] {
+						[group_kind_version] => group_kind_version,
+						_ => return Err(format!(
+							"definition {} looks like a list but its item's definition does not have a single group-version-kind",
+							definition_path).into()),
+					};
+	
+					let list_kubernetes_group_kind_version = match &definition.kubernetes_group_kind_versions[..] {
+						[group_kind_version] => group_kind_version,
+						_ => return Err(format!(
+							"definition {} looks like a list but it does not have a single group-version-kind",
+							definition_path).into()),
+					};
+	
+					let item_gkv_corresponds_to_list_gkv =
+						list_kubernetes_group_kind_version.group == item_kubernetes_group_kind_version.group &&
+						list_kubernetes_group_kind_version.version == item_kubernetes_group_kind_version.version &&
+						list_kubernetes_group_kind_version.kind == format!("{}List", item_kubernetes_group_kind_version.kind);
+					if !item_gkv_corresponds_to_list_gkv {
+						return Err(format!(
+							"defintion {} looks like a list but its group-version-kind does not correspond to its item's group-version-kind", definition_path).into());
+					}
+	
+					(item_ref_path.clone(), list_kubernetes_group_kind_version.kind.clone())
+				}
+				else {
+					return Err(format!("definition {} looks like a list but its items property is not a ref", definition_path).into());
+				};
+	
+			list_definition_paths.push((definition_path.clone(), item_ref_path, list_kind));
+	
+			if let Some((_, list_property_names)) = &list_properties {
+				let property_names: std::collections::BTreeSet<_> = properties.keys().cloned().collect();
+				if &property_names != list_property_names {
+					return Err(format!("Definition {} looks like a list but doesn't have the expected properties: {:?}", definition_path, properties).into());
+				}
+			}
+			else {
+				let mut properties = properties.clone();
+				properties.insert(
+					items_property_name.clone(),
+					(
+						crate::swagger20::Schema {
+							description: Some("List of objects".to_owned()),
+							kind: crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::Array {
+								items: Box::new(crate::swagger20::Schema {
+									description: None,
+									kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath {
+										path: "T".to_owned(),
+										can_be_default: None,
+									}),
+									kubernetes_group_kind_versions: vec![],
+									list_kind: None,
+								}),
+							}),
+							kubernetes_group_kind_versions: vec![],
+							list_kind: None,
+						},
+						true,
+					));
+				let property_names: std::collections::BTreeSet<_> = properties.keys().cloned().collect();
+	
+				list_properties = Some((metadata_schema.kind.clone(), property_names));
+			}
+		}
+	
+		let (metadata_schema_kind, _) = list_properties.ok_or("did not find any types that looked like a list")?;
+	
+	
+		// Synthesize `k8s_openapi::List<T>`
+	
+		spec.definitions.insert(
+			crate::swagger20::DefinitionPath("io.k8s.List".to_owned()),
+			crate::swagger20::Schema {
+				description: Some("List is a list of resources.".to_owned()),
+				kind: crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::ListDef { metadata: Box::new(metadata_schema_kind) }),
+				kubernetes_group_kind_versions: vec![],
+				list_kind: None,
+			});
+	
+	
+		// Remove all list types
+	
+		for (definition_path, item_ref_path, list_kind) in &list_definition_paths {
+			let item_definition = spec.definitions.get_mut(&crate::swagger20::DefinitionPath(item_ref_path.path.clone())).unwrap();
+			item_definition.list_kind = Some(list_kind.clone());
+	
+			let _ = spec.definitions.remove(definition_path);
+		}
+	
+	
+		// Replace references to all list types with refs to `k8s_openapi::List<T>`
+	
+		for (definition_path, item_ref_path, _) in list_definition_paths {
+			for definition in spec.definitions.values_mut() {
+				if let crate::swagger20::SchemaKind::Properties(properties) = &mut definition.kind {
+					for (field_value_schema, _) in properties.values_mut() {
+						let field_value_schema_kind = &mut field_value_schema.kind;
+						if let crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath { path, .. }) = field_value_schema_kind {
+							if path == &definition_path.0 {
+								*field_value_schema_kind = crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::ListRef {
+									items: Box::new(crate::swagger20::SchemaKind::Ref(item_ref_path.clone())),
+								});
+							}
+						}
+					}
+				}
+			}
+	
+			for operation in &mut spec.operations {
+				if let crate::swagger20::OperationResponses::Map(responses) = &mut operation.responses {
+					for response in responses.values_mut() {
+						let response_schema_kind = &mut response.kind;
+						if let crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath { path, .. }) = response_schema_kind {
+							if path == &definition_path.0 {
+								*response_schema_kind = crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::ListRef {
+									items: Box::new(crate::swagger20::SchemaKind::Ref(item_ref_path.clone())),
+								});
+							}
+						}
+					}
+				}
+				else {
+					unreachable!();
+				}
+			}
+		}
+	
+		Ok(())
+    }
+
+	fn requires_client_generation(&self) -> bool {
+		false
+	}
 }
 
 // Define the common types for API responses as `swagger20::Type::<>Def`, and replace all references to the original types with `swagger20::Type::<>Ref` for special codegen.
-pub(crate) fn response_types(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
-	const TYPES: &[(&str, fn(&mut crate::swagger20::Spec) -> Result<(&'static str, crate::swagger20::Type), crate::Error>)] = &[
-		("io.k8s.CreateResponse", create_response),
-		("io.k8s.DeleteResponse", delete_and_delete_collection_response),
-		("io.k8s.ListResponse", list_response),
-		("io.k8s.PatchResponse", patch_response),
-		("io.k8s.ReplaceResponse", replace_response),
-		("io.k8s.WatchResponse", watch_response),
-	];
+pub(crate) struct ResponseTypes;
 
+impl ResponseTypes {
 	fn create_response(spec: &mut crate::swagger20::Spec) -> Result<(&'static str, crate::swagger20::Type), crate::Error> {
 		let mut found = false;
 
@@ -1111,55 +1197,79 @@ pub(crate) fn response_types(spec: &mut crate::swagger20::Spec) -> Result<(), cr
 			crate::swagger20::Type::WatchResponse,
 		))
 	}
+}
 
-	for &(definition_path, run) in TYPES {
-		let (description, ty) = run(spec)?;
-
-		spec.definitions.insert(
-			crate::swagger20::DefinitionPath(definition_path.to_owned()),
-			crate::swagger20::Schema {
-				description: Some(description.to_owned()),
-				kind: crate::swagger20::SchemaKind::Ty(ty),
-				kubernetes_group_kind_versions: vec![],
-				list_kind: None,
-			});
+impl Fixup for ResponseTypes {
+	fn fixup(&self, spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
+		const TYPES: &[(&str, fn(&mut crate::swagger20::Spec) -> Result<(&'static str, crate::swagger20::Type), crate::Error>)] = &[
+			("io.k8s.CreateResponse", ResponseTypes::create_response),
+			("io.k8s.DeleteResponse", ResponseTypes::delete_and_delete_collection_response),
+			("io.k8s.ListResponse", ResponseTypes::list_response),
+			("io.k8s.PatchResponse", ResponseTypes::patch_response),
+			("io.k8s.ReplaceResponse", ResponseTypes::replace_response),
+			("io.k8s.WatchResponse", ResponseTypes::watch_response),
+		];
+		for &(definition_path, run) in TYPES {
+			let (description, ty) = run(spec)?;
+	
+			spec.definitions.insert(
+				crate::swagger20::DefinitionPath(definition_path.to_owned()),
+				crate::swagger20::Schema {
+					description: Some(description.to_owned()),
+					kind: crate::swagger20::SchemaKind::Ty(ty),
+					kubernetes_group_kind_versions: vec![],
+					list_kind: None,
+				});
+		}
+	
+		Ok(())
 	}
 
-	Ok(())
+	fn requires_client_generation(&self) -> bool {
+		true
+	}
 }
 
 // The `metadata` property of resource types is generally not optional, so override the property to be required.
 // For situations like PATCH requests where the property *is* optional, sending an empty object works the same.
-pub(crate) fn resource_metadata_not_optional(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
-	let mut found = false;
+pub(crate) struct ResourceMetadataNotOptional;
 
-	for definition in spec.definitions.values_mut() {
-		if let crate::swagger20::SchemaKind::Properties(properties) = &mut definition.kind {
-			let mut has_api_version = false;
-			let mut has_kind = false;
-			let mut has_optional_metadata = false;
+impl Fixup for ResourceMetadataNotOptional {
+	fn fixup(&self, spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
+		let mut found = false;
 
-			for (name, (_, required)) in &mut *properties {
-				has_api_version = has_api_version || name.0 == "apiVersion";
-				has_kind = has_kind || name.0 == "kind";
-				has_optional_metadata = has_optional_metadata || (name.0 == "metadata" && !*required);
+		for definition in spec.definitions.values_mut() {
+			if let crate::swagger20::SchemaKind::Properties(properties) = &mut definition.kind {
+				let mut has_api_version = false;
+				let mut has_kind = false;
+				let mut has_optional_metadata = false;
+	
+				for (name, (_, required)) in &mut *properties {
+					has_api_version = has_api_version || name.0 == "apiVersion";
+					has_kind = has_kind || name.0 == "kind";
+					has_optional_metadata = has_optional_metadata || (name.0 == "metadata" && !*required);
+					if has_api_version && has_kind && has_optional_metadata {
+						break;
+					}
+				}
+	
 				if has_api_version && has_kind && has_optional_metadata {
-					break;
+					let metadata = properties.get_mut(&crate::swagger20::PropertyName("metadata".to_owned())).unwrap();
+					metadata.1 = true;
+					found = true;
 				}
 			}
-
-			if has_api_version && has_kind && has_optional_metadata {
-				let metadata = properties.get_mut(&crate::swagger20::PropertyName("metadata".to_owned())).unwrap();
-				metadata.1 = true;
-				found = true;
-			}
+		}
+	
+		if found {
+			Ok(())
+		}
+		else {
+			Err("never applied override to make resource metadata non-optional".into())
 		}
 	}
 
-	if found {
-		Ok(())
-	}
-	else {
-		Err("never applied override to make resource metadata non-optional".into())
+	fn requires_client_generation(&self) -> bool {
+		false
 	}
 }

--- a/k8s-openapi-codegen/src/fixups/upstream_bugs.rs
+++ b/k8s-openapi-codegen/src/fixups/upstream_bugs.rs
@@ -2,77 +2,96 @@
 
 //! These fixups correspond to bugs in the upstream swagger spec.
 
+use crate::fixups::Fixup;
+
+
 // Path operation annotated with a "x-kubernetes-group-version-kind" that references a type that doesn't exist in the schema.
 //
 // Ref: https://github.com/kubernetes/kubernetes/pull/66807
-#[allow(clippy::if_same_then_else)]
-pub(crate) fn connect_options_gvk(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
-	let mut found = false;
+pub(crate) struct ConnectOptionsGvk;
 
-	for operation in &mut spec.operations {
-		if let Some(kubernetes_group_kind_version) = &mut operation.kubernetes_group_kind_version {
-			if kubernetes_group_kind_version.group.is_empty() && kubernetes_group_kind_version.version == "v1" {
-				let kind = &mut kubernetes_group_kind_version.kind;
-				if &*kind == "NodeProxyOptions" {
-					*kind = "Node".to_string();
-					found = true;
-				}
-				else if &*kind == "PodAttachOptions" {
-					*kind = "Pod".to_string();
-					found = true;
-				}
-				else if &*kind == "PodExecOptions" {
-					*kind = "Pod".to_string();
-					found = true;
-				}
-				else if &*kind == "PodPortForwardOptions" {
-					*kind = "Pod".to_string();
-					found = true;
-				}
-				else if &*kind == "PodProxyOptions" {
-					*kind = "Pod".to_string();
-					found = true;
-				}
-				else if &*kind == "ServiceProxyOptions" {
-					*kind = "Service".to_string();
-					found = true;
+impl Fixup for ConnectOptionsGvk {
+	#[allow(clippy::if_same_then_else)]
+	fn fixup(&self, spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
+		let mut found = false;
+
+		for operation in &mut spec.operations {
+			if let Some(kubernetes_group_kind_version) = &mut operation.kubernetes_group_kind_version {
+				if kubernetes_group_kind_version.group.is_empty() && kubernetes_group_kind_version.version == "v1" {
+					let kind = &mut kubernetes_group_kind_version.kind;
+					if &*kind == "NodeProxyOptions" {
+						*kind = "Node".to_string();
+						found = true;
+					}
+					else if &*kind == "PodAttachOptions" {
+						*kind = "Pod".to_string();
+						found = true;
+					}
+					else if &*kind == "PodExecOptions" {
+						*kind = "Pod".to_string();
+						found = true;
+					}
+					else if &*kind == "PodPortForwardOptions" {
+						*kind = "Pod".to_string();
+						found = true;
+					}
+					else if &*kind == "PodProxyOptions" {
+						*kind = "Pod".to_string();
+						found = true;
+					}
+					else if &*kind == "ServiceProxyOptions" {
+						*kind = "Service".to_string();
+						found = true;
+					}
 				}
 			}
 		}
+	
+		if found {
+			Ok(())
+		}
+		else {
+			Err("never applied connect options kubernetes_group_kind_version override".into())
+		}
 	}
 
-	if found {
-		Ok(())
-	}
-	else {
-		Err("never applied connect options kubernetes_group_kind_version override".into())
+	fn requires_client_generation(&self) -> bool {
+		true
 	}
 }
 
 // The spec says that `createAppsV1beta1NamespacedDeploymentRollback` returns `DeploymentRollback`, but it returns `Status`.
 //
 // Ref: https://github.com/kubernetes/kubernetes/pull/63837
-pub(crate) fn deployment_rollback_create_response_type(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
-	let mut found = false;
+pub(crate) struct DeploymentRollbackCreateResponseType;
 
-	if let Some(operation) = spec.operations.iter_mut().find(|o| o.id == "createAppsV1beta1NamespacedDeploymentRollback") {
-		if let crate::swagger20::OperationResponses::Map(responses) = &mut operation.responses {
-			for response in responses.values_mut() {
-				if let crate::swagger20::Schema { kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath { path, .. }), .. } = response {
-					if path == "io.k8s.api.apps.v1beta1.DeploymentRollback" {
-						*path = "io.k8s.apimachinery.pkg.apis.meta.v1.Status".to_owned();
-						found = true;
+impl Fixup for DeploymentRollbackCreateResponseType {
+	fn fixup(&self, spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
+		let mut found = false;
+
+		if let Some(operation) = spec.operations.iter_mut().find(|o| o.id == "createAppsV1beta1NamespacedDeploymentRollback") {
+			if let crate::swagger20::OperationResponses::Map(responses) = &mut operation.responses {
+				for response in responses.values_mut() {
+					if let crate::swagger20::Schema { kind: crate::swagger20::SchemaKind::Ref(crate::swagger20::RefPath { path, .. }), .. } = response {
+						if path == "io.k8s.api.apps.v1beta1.DeploymentRollback" {
+							*path = "io.k8s.apimachinery.pkg.apis.meta.v1.Status".to_owned();
+							found = true;
+						}
 					}
 				}
 			}
 		}
+	
+		if found {
+			Ok(())
+		}
+		else {
+			Err("never applied createAppsV1beta1NamespacedDeploymentRollback response type override".into())
+		}
 	}
 
-	if found {
-		Ok(())
-	}
-	else {
-		Err("never applied createAppsV1beta1NamespacedDeploymentRollback response type override".into())
+	fn requires_client_generation(&self) -> bool {
+		true
 	}
 }
 
@@ -80,61 +99,87 @@ pub(crate) fn deployment_rollback_create_response_type(spec: &mut crate::swagger
 //
 // Override it to be optional to achieve the same effect.
 pub(crate) mod optional_properties {
+	use crate::fixups::Fixup;
+
 	// `ContainerImage::names`
 	//
 	// Ref: https://github.com/kubernetes/kubernetes/issues/93606
-	pub(crate) fn containerimage(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
-		let definition_path = crate::swagger20::DefinitionPath("io.k8s.api.core.v1.ContainerImage".to_owned());
-		if let Some(definition) = spec.definitions.get_mut(&definition_path) {
-			if let crate::swagger20::SchemaKind::Properties(properties) = &mut definition.kind {
-				if let Some(property) = properties.get_mut(&crate::swagger20::PropertyName("names".to_string())) {
-					if property.1 {
-						property.1 = false;
-						return Ok(());
+	pub(crate) struct ContainerImage;
+
+	impl Fixup for ContainerImage {
+		fn fixup(&self, spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
+			let definition_path = crate::swagger20::DefinitionPath("io.k8s.api.core.v1.ContainerImage".to_owned());
+			if let Some(definition) = spec.definitions.get_mut(&definition_path) {
+				if let crate::swagger20::SchemaKind::Properties(properties) = &mut definition.kind {
+					if let Some(property) = properties.get_mut(&crate::swagger20::PropertyName("names".to_string())) {
+						if property.1 {
+							property.1 = false;
+							return Ok(());
+						}
 					}
 				}
 			}
+	
+			Err("never applied ContainerImage optional properties override".into())
 		}
 
-		Err("never applied ContainerImage optional properties override".into())
+		fn requires_client_generation(&self) -> bool {
+			false
+		}
 	}
 
 	// `CustomResourceDefinitionStatus::conditions`
 	//
 	// Ref: https://github.com/kubernetes/kubernetes/pull/64996
-	pub(crate) fn crdstatus(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
-		let definition_path = crate::swagger20::DefinitionPath("io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionStatus".to_owned());
-		if let Some(definition) = spec.definitions.get_mut(&definition_path) {
-			if let crate::swagger20::SchemaKind::Properties(properties) = &mut definition.kind {
-				if let Some(property) = properties.get_mut(&crate::swagger20::PropertyName("conditions".to_string())) {
-					if property.1 {
-						property.1 = false;
-						return Ok(());
+	pub(crate) struct CrdStatus;
+
+	impl Fixup for CrdStatus {
+		fn fixup(&self, spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
+			let definition_path = crate::swagger20::DefinitionPath("io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionStatus".to_owned());
+			if let Some(definition) = spec.definitions.get_mut(&definition_path) {
+				if let crate::swagger20::SchemaKind::Properties(properties) = &mut definition.kind {
+					if let Some(property) = properties.get_mut(&crate::swagger20::PropertyName("conditions".to_string())) {
+						if property.1 {
+							property.1 = false;
+							return Ok(());
+						}
 					}
 				}
 			}
+	
+			Err("never applied CustomResourceDefinitionStatus optional properties override".into())
 		}
 
-		Err("never applied CustomResourceDefinitionStatus optional properties override".into())
+		fn requires_client_generation(&self) -> bool {
+			false
+		}
 	}
 
 	// `PodDisruptionBudgetStatus::disruptedPods`
 	//
 	// Ref: https://github.com/kubernetes/kubernetes/pull/65041
-	pub(crate) fn poddisruptionbudgetstatus(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
-		let definition_path = crate::swagger20::DefinitionPath("io.k8s.api.policy.v1beta1.PodDisruptionBudgetStatus".to_owned());
-		if let Some(definition) = spec.definitions.get_mut(&definition_path) {
-			if let crate::swagger20::SchemaKind::Properties(properties) = &mut definition.kind {
-				if let Some(property) = properties.get_mut(&crate::swagger20::PropertyName("disruptedPods".to_string())) {
-					if property.1 {
-						property.1 = false;
-						return Ok(());
+	pub(crate) struct PdbStatus;
+
+	impl Fixup for PdbStatus {
+		fn fixup(&self, spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
+			let definition_path = crate::swagger20::DefinitionPath("io.k8s.api.policy.v1beta1.PodDisruptionBudgetStatus".to_owned());
+			if let Some(definition) = spec.definitions.get_mut(&definition_path) {
+				if let crate::swagger20::SchemaKind::Properties(properties) = &mut definition.kind {
+					if let Some(property) = properties.get_mut(&crate::swagger20::PropertyName("disruptedPods".to_string())) {
+						if property.1 {
+							property.1 = false;
+							return Ok(());
+						}
 					}
 				}
 			}
+	
+			Err("never applied PodDisruptionBudgetStatus optional properties override".into())
 		}
 
-		Err("never applied PodDisruptionBudgetStatus optional properties override".into())
+		fn requires_client_generation(&self) -> bool {
+			false
+		}
 	}
 }
 
@@ -149,41 +194,57 @@ pub(crate) mod optional_properties {
 //
 // https://github.com/kubernetes/kubernetes/pull/56434 will remove RawExtension and replace it with `{ type: "object" }`,
 // which would've already been mapped to `Ty(Any)` by `Ty::parse`, so just replicate that for `RawExtension` here.
-pub(crate) fn raw_extension_ty(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
-	let definition_path = crate::swagger20::DefinitionPath("io.k8s.apimachinery.pkg.runtime.RawExtension".to_owned());
-	if let Some(definition) = spec.definitions.get_mut(&definition_path) {
-		if !matches!(definition.kind, crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::Any)) {
-			definition.kind = crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::Any);
-			return Ok(());
+pub(crate) struct RawExtensionTy;
+
+impl Fixup for RawExtensionTy {
+	fn fixup(&self, spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
+		let definition_path = crate::swagger20::DefinitionPath("io.k8s.apimachinery.pkg.runtime.RawExtension".to_owned());
+		if let Some(definition) = spec.definitions.get_mut(&definition_path) {
+			if !matches!(definition.kind, crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::Any)) {
+				definition.kind = crate::swagger20::SchemaKind::Ty(crate::swagger20::Type::Any);
+				return Ok(());
+			}
 		}
+	
+		Err("never applied RawExtension override".into())
 	}
 
-	Err("never applied RawExtension override".into())
+	fn requires_client_generation(&self) -> bool {
+		false
+	}
 }
 
 // Remove `$ref`s under `io.k8s.kubernetes.pkg` since these are marked deprecated and point to corresponding definitions under `io.k8s.api`.
 // They only exist for backward-compatibility with 1.7's spec.
-pub(crate) fn remove_compat_refs(spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
-	const COMPAT_NAMESPACE: &[&str] = &["io", "k8s", "kubernetes", "pkg"];
+pub(crate) struct RemoveCompatRefs;
 
-	let mut to_remove = vec![];
+impl Fixup for RemoveCompatRefs {
+	fn fixup(&self, spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
+		const COMPAT_NAMESPACE: &[&str] = &["io", "k8s", "kubernetes", "pkg"];
 
-	for (definition_path, definition) in &spec.definitions {
-		if let crate::swagger20::SchemaKind::Ref(_) = definition.kind {
-			let parts: Vec<_> = definition_path.split('.').collect();
-			if parts.starts_with(COMPAT_NAMESPACE) {
-				to_remove.push(definition_path.clone());
+		let mut to_remove = vec![];
+	
+		for (definition_path, definition) in &spec.definitions {
+			if let crate::swagger20::SchemaKind::Ref(_) = definition.kind {
+				let parts: Vec<_> = definition_path.split('.').collect();
+				if parts.starts_with(COMPAT_NAMESPACE) {
+					to_remove.push(definition_path.clone());
+				}
 			}
 		}
+	
+		if to_remove.is_empty() {
+			return Err("never removed compat refs".into());
+		}
+	
+		for to_remove in to_remove {
+			spec.definitions.remove(&to_remove);
+		}
+	
+		Ok(())
 	}
 
-	if to_remove.is_empty() {
-		return Err("never removed compat refs".into());
+	fn requires_client_generation(&self) -> bool {
+		false
 	}
-
-	for to_remove in to_remove {
-		spec.definitions.remove(&to_remove);
-	}
-
-	Ok(())
 }

--- a/k8s-openapi-codegen/src/supported_version.rs
+++ b/k8s-openapi-codegen/src/supported_version.rs
@@ -1,3 +1,5 @@
+use crate::fixups::Fixup;
+
 pub(crate) const ALL: &[SupportedVersion] = &[
 	SupportedVersion::V1_11,
 	SupportedVersion::V1_12,
@@ -76,97 +78,102 @@ impl SupportedVersion {
 		}
 	}
 
-	pub(crate) fn fixup(self, spec: &mut crate::swagger20::Spec) -> Result<(), crate::Error> {
+	pub(crate) fn fixup(self, spec: &mut crate::swagger20::Spec, skip_client_generation: bool) -> Result<(), crate::Error> {
 		#[allow(clippy::match_same_arms)]
-		let upstream_bugs_fixups: &[fn(&mut crate::swagger20::Spec) -> Result<(), crate::Error>] = match self {
+		let upstream_bugs_fixups: &[&'static dyn Fixup] = match self {
 			SupportedVersion::V1_11 => &[
-				crate::fixups::upstream_bugs::deployment_rollback_create_response_type,
-				crate::fixups::upstream_bugs::optional_properties::containerimage,
-				crate::fixups::upstream_bugs::optional_properties::crdstatus,
-				crate::fixups::upstream_bugs::optional_properties::poddisruptionbudgetstatus,
-				crate::fixups::upstream_bugs::raw_extension_ty,
-				crate::fixups::upstream_bugs::remove_compat_refs,
+				&crate::fixups::upstream_bugs::DeploymentRollbackCreateResponseType,
+				&crate::fixups::upstream_bugs::optional_properties::ContainerImage,
+				&crate::fixups::upstream_bugs::optional_properties::CrdStatus,
+				&crate::fixups::upstream_bugs::optional_properties::PdbStatus,
+				&crate::fixups::upstream_bugs::RawExtensionTy,
+				&crate::fixups::upstream_bugs::RemoveCompatRefs,
 			],
 
 			SupportedVersion::V1_12 => &[
-				crate::fixups::upstream_bugs::connect_options_gvk,
-				crate::fixups::upstream_bugs::optional_properties::containerimage,
-				crate::fixups::upstream_bugs::optional_properties::crdstatus,
-				crate::fixups::upstream_bugs::raw_extension_ty,
-				crate::fixups::upstream_bugs::remove_compat_refs,
+				&crate::fixups::upstream_bugs::ConnectOptionsGvk,
+				&crate::fixups::upstream_bugs::optional_properties::ContainerImage,
+				&crate::fixups::upstream_bugs::optional_properties::CrdStatus,
+				&crate::fixups::upstream_bugs::RawExtensionTy,
+				&crate::fixups::upstream_bugs::RemoveCompatRefs,
 			],
 
 			SupportedVersion::V1_13 => &[
-				crate::fixups::upstream_bugs::connect_options_gvk,
-				crate::fixups::upstream_bugs::optional_properties::containerimage,
-				crate::fixups::upstream_bugs::optional_properties::crdstatus,
-				crate::fixups::upstream_bugs::raw_extension_ty,
-				crate::fixups::upstream_bugs::remove_compat_refs,
+				&crate::fixups::upstream_bugs::ConnectOptionsGvk,
+				&crate::fixups::upstream_bugs::optional_properties::ContainerImage,
+				&crate::fixups::upstream_bugs::optional_properties::CrdStatus,
+				&crate::fixups::upstream_bugs::RawExtensionTy,
+				&crate::fixups::upstream_bugs::RemoveCompatRefs,
 			],
 
 			SupportedVersion::V1_14 => &[
-				crate::fixups::upstream_bugs::connect_options_gvk,
-				crate::fixups::upstream_bugs::optional_properties::containerimage,
-				crate::fixups::upstream_bugs::optional_properties::crdstatus,
-				crate::fixups::upstream_bugs::raw_extension_ty,
+				&crate::fixups::upstream_bugs::ConnectOptionsGvk,
+				&crate::fixups::upstream_bugs::optional_properties::ContainerImage,
+				&crate::fixups::upstream_bugs::optional_properties::CrdStatus,
+				&crate::fixups::upstream_bugs::RawExtensionTy,
 			],
 
 			SupportedVersion::V1_15 => &[
-				crate::fixups::upstream_bugs::connect_options_gvk,
-				crate::fixups::upstream_bugs::optional_properties::containerimage,
-				crate::fixups::upstream_bugs::optional_properties::crdstatus,
-				crate::fixups::upstream_bugs::raw_extension_ty,
+				&crate::fixups::upstream_bugs::ConnectOptionsGvk,
+				&crate::fixups::upstream_bugs::optional_properties::ContainerImage,
+				&crate::fixups::upstream_bugs::optional_properties::CrdStatus,
+				&crate::fixups::upstream_bugs::RawExtensionTy,
 			],
 
 			SupportedVersion::V1_16 => &[
-				crate::fixups::upstream_bugs::connect_options_gvk,
-				crate::fixups::upstream_bugs::optional_properties::containerimage,
+				&crate::fixups::upstream_bugs::ConnectOptionsGvk,
+				&crate::fixups::upstream_bugs::optional_properties::ContainerImage,
 			],
 
 			SupportedVersion::V1_17 => &[
-				crate::fixups::upstream_bugs::connect_options_gvk,
-				crate::fixups::upstream_bugs::optional_properties::containerimage,
+				&crate::fixups::upstream_bugs::ConnectOptionsGvk,
+				&crate::fixups::upstream_bugs::optional_properties::ContainerImage,
 			],
 
 			SupportedVersion::V1_18 => &[
-				crate::fixups::upstream_bugs::connect_options_gvk,
-				crate::fixups::upstream_bugs::optional_properties::containerimage,
+				&crate::fixups::upstream_bugs::ConnectOptionsGvk,
+				&crate::fixups::upstream_bugs::optional_properties::ContainerImage,
 			],
 
 			SupportedVersion::V1_19 => &[
-				crate::fixups::upstream_bugs::connect_options_gvk,
-				crate::fixups::upstream_bugs::optional_properties::containerimage,
+				&crate::fixups::upstream_bugs::ConnectOptionsGvk,
+				&crate::fixups::upstream_bugs::optional_properties::ContainerImage,
 			],
 
 			SupportedVersion::V1_20 => &[
-				crate::fixups::upstream_bugs::connect_options_gvk,
-				crate::fixups::upstream_bugs::optional_properties::containerimage,
+				&crate::fixups::upstream_bugs::ConnectOptionsGvk,
+				&crate::fixups::upstream_bugs::optional_properties::ContainerImage,
 			],
 
 			SupportedVersion::V1_21 => &[
-				crate::fixups::upstream_bugs::connect_options_gvk,
-				crate::fixups::upstream_bugs::optional_properties::containerimage,
+				&crate::fixups::upstream_bugs::ConnectOptionsGvk,
+				&crate::fixups::upstream_bugs::optional_properties::ContainerImage,
 			],
 		};
 
-		let special_fixups: &[fn(&mut crate::swagger20::Spec) -> Result<(), crate::Error>] = &[
-			crate::fixups::special::json_ty::json_schema_props_or_array,
-			crate::fixups::special::json_ty::json_schema_props_or_bool,
-			crate::fixups::special::json_ty::json_schema_props_or_string_array,
-			crate::fixups::special::create_delete_optional,
-			crate::fixups::special::create_optionals,
-			crate::fixups::special::patch,
-			crate::fixups::special::remove_delete_collection_operations_query_parameters,
-			crate::fixups::special::remove_delete_operations_query_parameters,
-			crate::fixups::special::separate_watch_from_list_operations,
-			crate::fixups::special::watch_event,
-			crate::fixups::special::list, // Must run after separate_watch_from_list_operations
-			crate::fixups::special::response_types,
-			crate::fixups::special::resource_metadata_not_optional,
+		let special_fixups: &[&'static dyn Fixup] = &[
+			&crate::fixups::special::json_ty::JsonSchemaPropsOrArray,
+			&crate::fixups::special::json_ty::JsonSchemaPropsOrBool,
+			&crate::fixups::special::json_ty::JsonSchemaPropsOrStringArray,
+			&crate::fixups::special::CreateDeleteOptional,
+			&crate::fixups::special::CreateOptionals,
+			&crate::fixups::special::Patch,
+			&crate::fixups::special::RemoveDeleteCollectionOperationsQueryParameters,
+			&crate::fixups::special::RemoveDeleteOperationsQueryParameters,
+			&crate::fixups::special::SeparateWatchFromListOperations,
+			&crate::fixups::special::WatchEvent,
+			&crate::fixups::special::List, // Must run after separate_watch_from_list_operations
+			&crate::fixups::special::ResponseTypes,
+			&crate::fixups::special::ResourceMetadataNotOptional,
 		];
 
-		for fixup in upstream_bugs_fixups.iter().chain(special_fixups) {
-			fixup(spec)?;
+		let _ = skip_client_generation;
+
+		for fixup in upstream_bugs_fixups.iter().chain(special_fixups).copied() {
+			if skip_client_generation && fixup.requires_client_generation() {
+				continue;
+			}
+			fixup.fixup(spec)?;
 		}
 
 		Ok(())


### PR DESCRIPTION
This is a draft because currently, it still fails on `metrics.k8s.io`.