### PR TITLE
Add all subprojects to cargo workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,6 @@ v1_22 = []
 [package.metadata.docs.rs]
 # docs.rs generates docs for the latest version. To see the docs for an older version, please generate them yourself.
 features = ["v1_22"]
+
+[workspace]
+members = ["k8s-openapi-codegen", "k8s-openapi-codegen-common", "k8s-openapi-derive", "k8s-openapi-tests", "k8s-openapi-tests-macro-deps"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,4 +63,10 @@ v1_22 = []
 features = ["v1_22"]
 
 [workspace]
-members = ["k8s-openapi-codegen", "k8s-openapi-codegen-common", "k8s-openapi-derive", "k8s-openapi-tests", "k8s-openapi-tests-macro-deps"]
+members = [
+    "k8s-openapi-codegen",
+    "k8s-openapi-codegen-common",
+    "k8s-openapi-derive",
+    "k8s-openapi-tests",
+    "k8s-openapi-tests-macro-deps",
+]

--- a/k8s-openapi-codegen-common/Cargo.toml
+++ b/k8s-openapi-codegen-common/Cargo.toml
@@ -3,7 +3,6 @@ name = "k8s-openapi-codegen-common"
 version = "0.13.0"
 license = "Apache-2.0"
 authors = ["Arnavion <me@arnavion.dev>"]
-publish = false
 categories = ["api-bindings", "web-programming::http-client"]
 description = "Common code for the k8s-openapi code generator and k8s-openapi-derive"
 documentation = "https://arnavion.github.io/k8s-openapi/v0.13.x/k8s_openapi_codegen_common/"

--- a/k8s-openapi-codegen-common/Cargo.toml
+++ b/k8s-openapi-codegen-common/Cargo.toml
@@ -3,6 +3,7 @@ name = "k8s-openapi-codegen-common"
 version = "0.13.0"
 license = "Apache-2.0"
 authors = ["Arnavion <me@arnavion.dev>"]
+publish = false
 categories = ["api-bindings", "web-programming::http-client"]
 description = "Common code for the k8s-openapi code generator and k8s-openapi-derive"
 documentation = "https://arnavion.github.io/k8s-openapi/v0.13.x/k8s_openapi_codegen_common/"


### PR DESCRIPTION
This ensures that Rust-Analyzer can find all subprojects, and allows Cargo to perform treewide actions (with the `--workspace` flag).