### PR TITLE
Change int-or-string to declare in way kubernetes expects. Fixes #152

### DIFF
--- a/k8s-openapi-codegen-common/src/templates/impl_schema.rs
+++ b/k8s-openapi-codegen-common/src/templates/impl_schema.rs
@@ -353,9 +353,9 @@ fn gen_type(
         }
 
         swagger20::Type::IntOrString => {
-            writeln!(out,
-                "{indent}instance_type: Some({local}schemars::schema::SingleOrVec::Single(Box::new({local}schemars::schema::InstanceType::String))),")?;
-            writeln!(out, r#"{indent}format: Some("int-or-string".to_owned()),"#)?;
+            writeln!(out, r#"{indent}extensions: crate::schemars::Map::from(["#)?;
+            writeln!(out, r#"{indent}    ("x-kubernetes-int-or-string".to_owned(), crate::serde_json::Value::Bool(true))"#)?;
+            writeln!(out, r#"{indent}]),"#)?;
         }
 
         swagger20::Type::Patch => {

--- a/src/v1_24/apimachinery/pkg/util/intstr/int_or_string.rs
+++ b/src/v1_24/apimachinery/pkg/util/intstr/int_or_string.rs
@@ -78,8 +78,9 @@ impl crate::schemars::JsonSchema for IntOrString {
                 description: Some("IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.".to_owned()),
                 ..Default::default()
             })),
-            instance_type: Some(crate::schemars::schema::SingleOrVec::Single(Box::new(crate::schemars::schema::InstanceType::String))),
-            format: Some("int-or-string".to_owned()),
+            extensions: crate::schemars::Map::from([
+                ("x-kubernetes-int-or-string".to_owned(), crate::serde_json::Value::Bool(true))
+            ]),
             ..Default::default()
         })
     }

--- a/src/v1_25/apimachinery/pkg/util/intstr/int_or_string.rs
+++ b/src/v1_25/apimachinery/pkg/util/intstr/int_or_string.rs
@@ -78,8 +78,9 @@ impl crate::schemars::JsonSchema for IntOrString {
                 description: Some("IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.".to_owned()),
                 ..Default::default()
             })),
-            instance_type: Some(crate::schemars::schema::SingleOrVec::Single(Box::new(crate::schemars::schema::InstanceType::String))),
-            format: Some("int-or-string".to_owned()),
+            extensions: crate::schemars::Map::from([
+                ("x-kubernetes-int-or-string".to_owned(), crate::serde_json::Value::Bool(true))
+            ]),
             ..Default::default()
         })
     }

--- a/src/v1_26/apimachinery/pkg/util/intstr/int_or_string.rs
+++ b/src/v1_26/apimachinery/pkg/util/intstr/int_or_string.rs
@@ -78,8 +78,9 @@ impl crate::schemars::JsonSchema for IntOrString {
                 description: Some("IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.".to_owned()),
                 ..Default::default()
             })),
-            instance_type: Some(crate::schemars::schema::SingleOrVec::Single(Box::new(crate::schemars::schema::InstanceType::String))),
-            format: Some("int-or-string".to_owned()),
+            extensions: crate::schemars::Map::from([
+                ("x-kubernetes-int-or-string".to_owned(), crate::serde_json::Value::Bool(true))
+            ]),
             ..Default::default()
         })
     }

--- a/src/v1_27/apimachinery/pkg/util/intstr/int_or_string.rs
+++ b/src/v1_27/apimachinery/pkg/util/intstr/int_or_string.rs
@@ -78,8 +78,9 @@ impl crate::schemars::JsonSchema for IntOrString {
                 description: Some("IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.".to_owned()),
                 ..Default::default()
             })),
-            instance_type: Some(crate::schemars::schema::SingleOrVec::Single(Box::new(crate::schemars::schema::InstanceType::String))),
-            format: Some("int-or-string".to_owned()),
+            extensions: crate::schemars::Map::from([
+                ("x-kubernetes-int-or-string".to_owned(), crate::serde_json::Value::Bool(true))
+            ]),
             ..Default::default()
         })
     }

--- a/src/v1_28/apimachinery/pkg/util/intstr/int_or_string.rs
+++ b/src/v1_28/apimachinery/pkg/util/intstr/int_or_string.rs
@@ -78,8 +78,9 @@ impl crate::schemars::JsonSchema for IntOrString {
                 description: Some("IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.".to_owned()),
                 ..Default::default()
             })),
-            instance_type: Some(crate::schemars::schema::SingleOrVec::Single(Box::new(crate::schemars::schema::InstanceType::String))),
-            format: Some("int-or-string".to_owned()),
+            extensions: crate::schemars::Map::from([
+                ("x-kubernetes-int-or-string".to_owned(), crate::serde_json::Value::Bool(true))
+            ]),
             ..Default::default()
         })
     }

--- a/src/v1_29/apimachinery/pkg/util/intstr/int_or_string.rs
+++ b/src/v1_29/apimachinery/pkg/util/intstr/int_or_string.rs
@@ -78,8 +78,9 @@ impl crate::schemars::JsonSchema for IntOrString {
                 description: Some("IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.".to_owned()),
                 ..Default::default()
             })),
-            instance_type: Some(crate::schemars::schema::SingleOrVec::Single(Box::new(crate::schemars::schema::InstanceType::String))),
-            format: Some("int-or-string".to_owned()),
+            extensions: crate::schemars::Map::from([
+                ("x-kubernetes-int-or-string".to_owned(), crate::serde_json::Value::Bool(true))
+            ]),
             ..Default::default()
         })
     }


### PR DESCRIPTION
I haven't been able to due `flock` not being available on my windows machine.

I have however patched it into my project where i encountered the issue (#152) originally and it seems to resolve it. At least i can use the PodTemplateSpec to deploy new pods even if the port is specified purely as a number. 