### PR TITLE
chore: remove serde-value dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ serde = { version = "1", default-features = false }
 serde_json = { version = "1", default-features = false, features = [
     "alloc", # "serde_json requires that either `std` (default) or `alloc` feature is enabled"
 ] }
-serde-value = { version = "0.7", default-features = false }
 
 [features]
 # Each feature corresponds to a supported version of Kubernetes

--- a/k8s-openapi-codegen-common/src/templates/impl_deserialize.rs
+++ b/k8s-openapi-codegen-common/src/templates/impl_deserialize.rs
@@ -69,7 +69,7 @@ pub(crate) fn generate(
             flattened_field = Some((field_name, field_type_name));
 
             writeln!(field_value_defs,
-                r#"                let mut value_{field_name}: std::collections::BTreeMap<{local}serde_value::Value, {local}serde_value::Value> = Default::default();"#)?;
+                r#"                let mut value_{field_name}: {local}serde_json::Map<String, {local}serde_json::Value> = Default::default();"#)?;
         }
         else {
             writeln!(fields_string, "            Key_{field_name},")?;
@@ -133,16 +133,12 @@ pub(crate) fn generate(
         writeln!(str_to_field_match_arms, "                            v => Field::Other(v.to_owned()),")?;
 
         writeln!(field_value_match_arms,
-            "                        Field::Other(key) => {{ value_{field_name}.insert({local}serde_value::Value::String(key), {local}serde::de::MapAccess::next_value(&mut map)?); }},")?;
+            "                        Field::Other(key) => {{ value_{field_name}.insert(key, {local}serde::de::MapAccess::next_value(&mut map)?); }},")?;
 
         writeln!(field_value_assignment,
             "                    {field_name}: {{")?;
         writeln!(field_value_assignment,
-            "                        let value_{field_name} = {local}serde_value::Value::Map(value_{field_name});")?;
-        writeln!(field_value_assignment,
-            "                        let value_{field_name} = {local}serde_value::ValueDeserializer::new(value_{field_name});")?;
-        writeln!(field_value_assignment,
-            "                        let value_{field_name} = {local}serde::Deserialize::deserialize(value_{field_name})?;")?;
+            "                        let value_{field_name} = {local}serde::Deserialize::deserialize(value_{field_name}).map_err({local}serde::de::Error::custom)?;")?;
         writeln!(field_value_assignment,
             "                        value_{field_name}")?;
         writeln!(field_value_assignment,

--- a/k8s-openapi-codegen-common/templates/watch_event.rs
+++ b/k8s-openapi-codegen-common/templates/watch_event.rs
@@ -92,7 +92,7 @@ impl<'de, T> {local}serde::Deserialize<'de> for {type_name}<T> where T: {local}s
 
             fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error> where A: {local}serde::de::MapAccess<'de> {{
                 let mut value_type: Option<WatchEventType> = None;
-                let mut value_object: Option<{local}serde_value::Value> = None;
+                let mut value_object: Option<{local}serde_json::Value> = None;
 
                 while let Some(key) = {local}serde::de::MapAccess::next_key::<Field>(&mut map)? {{
                     match key {{
@@ -107,20 +107,16 @@ impl<'de, T> {local}serde::Deserialize<'de> for {type_name}<T> where T: {local}s
 
                 Ok(match value_type {{
                     WatchEventType::Added => {{
-                        let value_object = {local}serde_value::ValueDeserializer::new(value_object);
-                        {type_name}::Added({local}serde::Deserialize::deserialize(value_object)?)
+                        {type_name}::Added({local}serde::Deserialize::deserialize(value_object).map_err({local}serde::de::Error::custom)?)
                     }},
                     WatchEventType::Deleted => {{
-                        let value_object = {local}serde_value::ValueDeserializer::new(value_object);
-                        {type_name}::Deleted({local}serde::Deserialize::deserialize(value_object)?)
+                        {type_name}::Deleted({local}serde::Deserialize::deserialize(value_object).map_err({local}serde::de::Error::custom)?)
                     }},
                     WatchEventType::Modified => {{
-                        let value_object = {local}serde_value::ValueDeserializer::new(value_object);
-                        {type_name}::Modified({local}serde::Deserialize::deserialize(value_object)?)
+                        {type_name}::Modified({local}serde::Deserialize::deserialize(value_object).map_err({local}serde::de::Error::custom)?)
                     }},
                     WatchEventType::Bookmark => {{
-                        let value_object = {local}serde_value::ValueDeserializer::new(value_object);
-                        let value: BookmarkObject<'static> = {local}serde::Deserialize::deserialize(value_object)?;
+                        let value: BookmarkObject<'static> = {local}serde::Deserialize::deserialize(value_object).map_err({local}serde::de::Error::custom)?;
                         {type_name}::Bookmark {{
                             annotations: value.metadata.annotations.into_owned(),
                             resource_version: value.metadata.resource_version.into_owned(),
@@ -128,18 +124,17 @@ impl<'de, T> {local}serde::Deserialize<'de> for {type_name}<T> where T: {local}s
                     }},
                     WatchEventType::Error => {{
                         let is_status =
-                            if let {local}serde_value::Value::Map(map) = &value_object {{
-                                matches!(map.get(&{local}serde_value::Value::String("kind".to_owned())), Some({local}serde_value::Value::String(s)) if s == "Status")
+                            if let {local}serde_json::Value::Object(map) = &value_object {{
+                                matches!(map.get("kind"), Some({local}serde_json::Value::String(s)) if s == "Status")
                             }}
                             else {{
                                 false
                             }};
-                        let value_object = {local}serde_value::ValueDeserializer::new(value_object);
                         if is_status {{
-                            {type_name}::ErrorStatus({local}serde::Deserialize::deserialize(value_object)?)
+                            {type_name}::ErrorStatus({local}serde::Deserialize::deserialize(value_object).map_err({local}serde::de::Error::custom)?)
                         }}
                         else {{
-                            {type_name}::ErrorOther({local}serde::Deserialize::deserialize(value_object)?)
+                            {type_name}::ErrorOther({local}serde::Deserialize::deserialize(value_object).map_err({local}serde::de::Error::custom)?)
                         }}
                     }},
                 }})

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,6 @@ pub use chrono;
 pub use schemars;
 pub use serde;
 pub use serde_json;
-pub use serde_value;
 
 
 #[path = "byte_string.rs"]


### PR DESCRIPTION
Hello, this PR just removes the old `serde-value` dependency.

The package `serde-value` seems not to be maintained actively.
The last commit was in 2020.

The package is functionally fine.
However, when the `std` dependency needs to be removed, `ordered-float`, a sub-dependency of the `serde-value`, requires the `std` library.
This requires explicit patches from the user and is unproductive.

Therefore, this PR is a preparatory work for `k8s-openapi` to have the `std` feature optional.
