### PR TITLE
Fix StatefulSet volumeClaimTemplates deep merging by merging by name

### DIFF
--- a/k8s-openapi-codegen/src/fixups/upstream_bugs.rs
+++ b/k8s-openapi-codegen/src/fixups/upstream_bugs.rs
@@ -49,6 +49,50 @@ pub(crate) fn connect_options_gvk(spec: &mut crate::swagger20::Spec) -> Result<(
     }
 }
 
+// `StatefulSetSpec::volumeClaimTemplates` should be a map list keyed by `metadata.name`.
+//
+// The upstream Go source annotates `StatefulSetSpec.volumeClaimTemplates` with `// +listType=atomic`,
+// which propagates to `x-kubernetes-list-type: atomic` in the OpenAPI spec. Semantically it should
+// be a map list keyed by `metadata.name`, because each PVC in a StatefulSet has a unique name and
+// merging by identity is the correct behavior.
+//
+// One possible reason this is not fixed upstream yet could be a limitation of the Kubernetes
+// annotation system: `// +listMapKey=<field>` only supports direct scalar fields on the item type,
+// but `PersistentVolumeClaim` carries its name via an embedded `ObjectMeta` (i.e. `metadata.name`
+// in JSON), not as a top-level field. There is no existing precedent or tooling support for a
+// nested `listMapKey` path in the Kubernetes codebase.
+//
+// We therefore fix it here by overriding the merge type after parsing the spec.
+//
+// Ref: https://github.com/kubernetes/kubernetes/issues/74819
+pub(crate) fn appsv1_statefulsetspec_volume_claim_templates_merge_strategy(
+    spec: &mut crate::swagger20::Spec,
+) -> Result<(), crate::Error> {
+    let definition_path =
+    crate::swagger20::DefinitionPath("io.k8s.api.apps.v1.StatefulSetSpec".to_owned());
+    if let Some(definition) = spec.definitions.get_mut(&definition_path) {
+        if let crate::swagger20::SchemaKind::Properties(properties) = &mut definition.kind {
+            if let Some((property_schema, _required)) = properties.get_mut("volumeClaimTemplates") {
+                if let crate::swagger20::MergeType::List { strategy, keys, .. } =
+                    &mut property_schema.merge_type
+                    {
+                        if *strategy == crate::swagger20::KubernetesListType::Atomic && keys.is_empty()
+                        {
+                            *strategy = crate::swagger20::KubernetesListType::Map;
+                            *keys = vec!["metadata.name".to_string()];
+                            return Ok(());
+                        }
+                    }
+            }
+        }
+    }
+
+    Err(
+        "never applied apps.k8s.io/v1.StatefulSetSpec volumeClaimTemplates list merge override"
+        .into(),
+    )
+}
+
 // The spec says that this property is an array, but it can be null.
 //
 // Override it to be optional to achieve the same effect.

--- a/k8s-openapi-codegen/src/supported_version.rs
+++ b/k8s-openapi-codegen/src/supported_version.rs
@@ -51,6 +51,7 @@ impl SupportedVersion {
         let upstream_bugs_fixups: &[fn(&mut crate::swagger20::Spec) -> Result<(), crate::Error>] = match self {
             SupportedVersion::V1_31 => &[
                 crate::fixups::upstream_bugs::connect_options_gvk,
+                crate::fixups::upstream_bugs::appsv1_statefulsetspec_volume_claim_templates_merge_strategy,
                 crate::fixups::upstream_bugs::optional_properties::appsv1_statefulsetspec,
                 crate::fixups::upstream_bugs::optional_properties::eventsv1_event,
                 crate::fixups::upstream_bugs::optional_properties::networkingv1_networkpolicyspec,
@@ -66,6 +67,7 @@ impl SupportedVersion {
 
             SupportedVersion::V1_32 => &[
                 crate::fixups::upstream_bugs::connect_options_gvk,
+                crate::fixups::upstream_bugs::appsv1_statefulsetspec_volume_claim_templates_merge_strategy,
                 crate::fixups::upstream_bugs::optional_properties::appsv1_statefulsetspec,
                 crate::fixups::upstream_bugs::optional_properties::eventsv1_event,
                 crate::fixups::upstream_bugs::optional_properties::networkingv1_networkpolicyspec,
@@ -81,6 +83,7 @@ impl SupportedVersion {
 
             SupportedVersion::V1_33 => &[
                 crate::fixups::upstream_bugs::connect_options_gvk,
+                crate::fixups::upstream_bugs::appsv1_statefulsetspec_volume_claim_templates_merge_strategy,
                 crate::fixups::upstream_bugs::optional_properties::eventsv1_event,
                 crate::fixups::upstream_bugs::optional_properties::networkingv1_networkpolicyspec,
                 crate::fixups::upstream_bugs::required_properties::config_map_env_source,
@@ -95,6 +98,7 @@ impl SupportedVersion {
 
             SupportedVersion::V1_34 => &[
                 crate::fixups::upstream_bugs::connect_options_gvk,
+                crate::fixups::upstream_bugs::appsv1_statefulsetspec_volume_claim_templates_merge_strategy,
                 crate::fixups::upstream_bugs::optional_properties::eventsv1_event,
                 crate::fixups::upstream_bugs::required_properties::config_map_env_source,
                 crate::fixups::upstream_bugs::required_properties::config_map_key_selector,
@@ -108,6 +112,7 @@ impl SupportedVersion {
 
             SupportedVersion::V1_35 => &[
                 crate::fixups::upstream_bugs::connect_options_gvk,
+                crate::fixups::upstream_bugs::appsv1_statefulsetspec_volume_claim_templates_merge_strategy,
                 crate::fixups::upstream_bugs::optional_properties::eventsv1_event,
                 crate::fixups::upstream_bugs::required_properties::config_map_env_source,
                 crate::fixups::upstream_bugs::required_properties::config_map_key_selector,

--- a/k8s-openapi-tests/src/deep_merge.rs
+++ b/k8s-openapi-tests/src/deep_merge.rs
@@ -1,0 +1,88 @@
+use std::collections::BTreeMap;
+
+use k8s_openapi::{
+    api::{
+        apps::v1::StatefulSetSpec,
+        core::v1::{PersistentVolumeClaim, PersistentVolumeClaimSpec, VolumeResourceRequirements},
+    },
+    apimachinery::pkg::{api::resource::Quantity, apis::meta::v1::ObjectMeta},
+    DeepMerge,
+};
+
+#[test]
+fn stateful_set_volume_claim_templates_merge_by_name() {
+    let make_pvc = |name: &str, storage_class: Option<&str>, storage: &str| PersistentVolumeClaim {
+        metadata: ObjectMeta {
+            name: Some(name.to_owned()),
+            ..Default::default()
+        },
+        spec: Some(PersistentVolumeClaimSpec {
+            storage_class_name: storage_class.map(ToOwned::to_owned),
+            resources: Some(VolumeResourceRequirements {
+                requests: Some(BTreeMap::from([(
+                    "storage".to_owned(),
+                    Quantity(storage.to_owned()),
+                )])),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let mut base = StatefulSetSpec {
+        volume_claim_templates: Some(vec![
+            make_pvc("data", Some("fast"), "10Gi"),
+            make_pvc("logs", Some("slow"), "1Gi"),
+        ]),
+        ..Default::default()
+    };
+
+    // Let's assume the data PVC needs more storage space
+    let patch = StatefulSetSpec {
+        volume_claim_templates: Some(vec![make_pvc("data", None, "1024Gi")]),
+        ..Default::default()
+    };
+
+    base.merge_from(patch);
+
+    let pvcs = base
+        .volume_claim_templates
+        .expect("volume_claim_templates should be present");
+
+    assert_eq!(pvcs.len(), 2, "both PVCs should be present after map merge");
+
+    let data_pvc = pvcs
+        .iter()
+        .find(|p| p.metadata.name.as_deref() == Some("data"))
+        .expect("data PVC should be present");
+    assert_eq!(
+        data_pvc
+            .spec
+            .as_ref()
+            .and_then(|s| s.storage_class_name.as_deref()),
+        Some("fast"),
+        "data PVC storage class should be untouched",
+    );
+    assert_eq!(
+        data_pvc
+            .spec
+            .as_ref()
+            .and_then(|s| s.resources.as_ref())
+            .and_then(|r| r.requests.as_ref())
+            .and_then(|r| r.get("storage"))
+            .map(|q| q.0.as_str()),
+        Some("1024Gi"),
+        "data PVC storage request should be updated",
+    );
+
+    let logs_pvc = pvcs
+        .iter()
+        .find(|p| p.metadata.name.as_deref() == Some("logs"))
+        .expect("logs PVC should be retained after map merge");
+    assert_eq!(
+        logs_pvc,
+        &make_pvc("logs", Some("slow"), "1Gi"),
+        "logs PVC should be untouched"
+    );
+}

--- a/k8s-openapi-tests/src/lib.rs
+++ b/k8s-openapi-tests/src/lib.rs
@@ -502,6 +502,8 @@ mod clientset;
 
 mod custom_resource_definition;
 
+mod deep_merge;
+
 mod deserialize_leniency;
 
 mod deployment;

--- a/src/v1_31/api/apps/v1/stateful_set_spec.rs
+++ b/src/v1_31/api/apps/v1/stateful_set_spec.rs
@@ -49,7 +49,14 @@ impl crate::DeepMerge for StatefulSetSpec {
         crate::DeepMerge::merge_from(&mut self.service_name, other.service_name);
         crate::DeepMerge::merge_from(&mut self.template, other.template);
         crate::DeepMerge::merge_from(&mut self.update_strategy, other.update_strategy);
-        crate::merge_strategies::list::atomic(&mut self.volume_claim_templates, other.volume_claim_templates);
+        crate::merge_strategies::list::map(
+            &mut self.volume_claim_templates,
+            other.volume_claim_templates,
+            &[|lhs, rhs| lhs.metadata.name == rhs.metadata.name],
+            |current_item, other_item| {
+                crate::DeepMerge::merge_from(current_item, other_item);
+            },
+        );
     }
 }
 

--- a/src/v1_32/api/apps/v1/stateful_set_spec.rs
+++ b/src/v1_32/api/apps/v1/stateful_set_spec.rs
@@ -49,7 +49,14 @@ impl crate::DeepMerge for StatefulSetSpec {
         crate::DeepMerge::merge_from(&mut self.service_name, other.service_name);
         crate::DeepMerge::merge_from(&mut self.template, other.template);
         crate::DeepMerge::merge_from(&mut self.update_strategy, other.update_strategy);
-        crate::merge_strategies::list::atomic(&mut self.volume_claim_templates, other.volume_claim_templates);
+        crate::merge_strategies::list::map(
+            &mut self.volume_claim_templates,
+            other.volume_claim_templates,
+            &[|lhs, rhs| lhs.metadata.name == rhs.metadata.name],
+            |current_item, other_item| {
+                crate::DeepMerge::merge_from(current_item, other_item);
+            },
+        );
     }
 }
 

--- a/src/v1_33/api/apps/v1/stateful_set_spec.rs
+++ b/src/v1_33/api/apps/v1/stateful_set_spec.rs
@@ -49,7 +49,14 @@ impl crate::DeepMerge for StatefulSetSpec {
         crate::DeepMerge::merge_from(&mut self.service_name, other.service_name);
         crate::DeepMerge::merge_from(&mut self.template, other.template);
         crate::DeepMerge::merge_from(&mut self.update_strategy, other.update_strategy);
-        crate::merge_strategies::list::atomic(&mut self.volume_claim_templates, other.volume_claim_templates);
+        crate::merge_strategies::list::map(
+            &mut self.volume_claim_templates,
+            other.volume_claim_templates,
+            &[|lhs, rhs| lhs.metadata.name == rhs.metadata.name],
+            |current_item, other_item| {
+                crate::DeepMerge::merge_from(current_item, other_item);
+            },
+        );
     }
 }
 

--- a/src/v1_34/api/apps/v1/stateful_set_spec.rs
+++ b/src/v1_34/api/apps/v1/stateful_set_spec.rs
@@ -49,7 +49,14 @@ impl crate::DeepMerge for StatefulSetSpec {
         crate::DeepMerge::merge_from(&mut self.service_name, other.service_name);
         crate::DeepMerge::merge_from(&mut self.template, other.template);
         crate::DeepMerge::merge_from(&mut self.update_strategy, other.update_strategy);
-        crate::merge_strategies::list::atomic(&mut self.volume_claim_templates, other.volume_claim_templates);
+        crate::merge_strategies::list::map(
+            &mut self.volume_claim_templates,
+            other.volume_claim_templates,
+            &[|lhs, rhs| lhs.metadata.name == rhs.metadata.name],
+            |current_item, other_item| {
+                crate::DeepMerge::merge_from(current_item, other_item);
+            },
+        );
     }
 }
 

--- a/src/v1_35/api/apps/v1/stateful_set_spec.rs
+++ b/src/v1_35/api/apps/v1/stateful_set_spec.rs
@@ -49,7 +49,14 @@ impl crate::DeepMerge for StatefulSetSpec {
         crate::DeepMerge::merge_from(&mut self.service_name, other.service_name);
         crate::DeepMerge::merge_from(&mut self.template, other.template);
         crate::DeepMerge::merge_from(&mut self.update_strategy, other.update_strategy);
-        crate::merge_strategies::list::atomic(&mut self.volume_claim_templates, other.volume_claim_templates);
+        crate::merge_strategies::list::map(
+            &mut self.volume_claim_templates,
+            other.volume_claim_templates,
+            &[|lhs, rhs| lhs.metadata.name == rhs.metadata.name],
+            |current_item, other_item| {
+                crate::DeepMerge::merge_from(current_item, other_item);
+            },
+        );
     }
 }
 


### PR DESCRIPTION
While deep merging StatefulSets we noticed a bug while the merge of `volumeClaimTemplates` (see the added unit-test).

Our research brought up https://github.com/kubernetes/kubernetes/issues/74819, which confirms that the openapi spec has a wrong merge type (it uses atomic instead of merging by `metadata.name`).

As the issue was opened back in 2019 and was closed, from my perspective it's very unlikely that it will be fixed soon.
Thus, I propose to patch it here.
